### PR TITLE
Add simba command for matchms-based spectral networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,57 @@ The notebook demonstrates:
 
 ---
 
-## 📚 Training Your Custom SIMBA Model
+## Molecular Networking Using SIMBA
+
+Molecular networking computes all-vs-all pairwise structural similarity across a single set of spectra, producing a graph where nodes are spectra and edges connect structurally related compounds. This is analogous to GNPS molecular networking but uses SIMBA's learned structural distance predictions instead of cosine similarity.
+
+> **Note:** Input spectra are assumed to be deduplicated — one representative spectrum per compound. If your dataset contains multiple spectra per compound (e.g. from replicate injections), remove redundant entries before running molecular networking to avoid spurious high-similarity edges between duplicates.
+
+### Usage Example
+
+```bash
+simba molecular-network \
+  --model-path /path/to/model.ckpt \
+  --input-spectra /path/to/spectra.mgf \
+  --output-dir /path/to/output
+```
+
+**Common Parameters:**
+* `--model-path`: Path to trained SIMBA model checkpoint (.ckpt file) — **REQUIRED**
+* `--input-spectra`: Path to spectra file (.mgf format) — **REQUIRED**
+* `--output-dir`: Directory where results will be saved — **REQUIRED**
+* `molecular_network.score_cutoff`: Minimum similarity to create an edge (default: 0.5)
+* `molecular_network.top_n`: Top-N candidates considered per node (default: 20)
+* `molecular_network.max_links`: Maximum edges per node (default: 10)
+* `molecular_network.link_method`: Edge selection strategy — `single` (either end qualifies) or `mutual` (both ends must qualify) (default: single)
+* `molecular_network.keep_unconnected_nodes`: Include isolated spectra as singleton nodes (default: true)
+* `molecular_network.graph_format`: Output format — `graphml`, `gexf`, `cyjs`, `gml`, `json` (default: graphml)
+* `molecular_network.device`: Hardware device: `cpu` or `gpu` (default: cpu)
+* `molecular_network.use_gnps_format`: Set true if the input MGF uses GNPS-style headers (default: false)
+* `molecular_network.filter_spectra`: Apply quality filters (min 6 peaks, protonated adducts only). Default false — every spectrum becomes a node (default: false)
+* `molecular_network.precomputed_mces`: Path to a `similarity_mces.npy` from a previous run — skips model inference (default: null)
+* `molecular_network.plot`: Save a `network_plot.png` visualisation alongside the graph file (default: false)
+* `molecular_network.plot_label_key`: MGF metadata field to use as node labels in the plot (e.g. `formula`, `inchikey`). When null, MGF order index is used (default: null)
+
+**Output Files:**
+- `molecular_network.<format>`: Spectral network in the chosen format (default: `molecular_network.graphml`), loadable in Cytoscape or any NetworkX-compatible tool
+- `similarity_mces.npy`: Raw `[N×N]` predicted MCES distance matrix (can be reused with `precomputed_mces`)
+
+**Score Normalization:**
+
+MCES distances are converted to similarity scores as `sim = 1 - mces / max_mces`, where `max_mces` is the model's training cap (40). A score of 1.0 means identical structures; 0.0 means MCES ≥ 40 (no significant shared substructure).
+
+**Loading the network in Python:**
+
+```python
+import networkx as nx
+G = nx.read_graphml("output/molecular_network.graphml")
+print(f"{G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
+```
+
+---
+
+## �📚 Training Your Custom SIMBA Model
 
 SIMBA supports training custom models using your own MS/MS datasets in `.mgf` format.
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ print(f"{G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
 
 ---
 
-## �📚 Training Your Custom SIMBA Model
+## 📚 Training Your Custom SIMBA Model
 
 SIMBA supports training custom models using your own MS/MS datasets in `.mgf` format.
 

--- a/simba/cli.py
+++ b/simba/cli.py
@@ -4,6 +4,7 @@ import click
 
 from simba.commands.analog_discovery import analog_discovery
 from simba.commands.inference import inference
+from simba.commands.molecular_networking import molecular_network
 from simba.commands.preprocess import preprocess
 from simba.commands.train import train
 
@@ -22,6 +23,7 @@ def cli():
 # Register commands
 cli.add_command(analog_discovery)
 cli.add_command(inference)
+cli.add_command(molecular_network)
 cli.add_command(preprocess)
 cli.add_command(train)
 

--- a/simba/commands/molecular_networking.py
+++ b/simba/commands/molecular_networking.py
@@ -1,0 +1,118 @@
+"""Molecular networking command for SIMBA CLI."""
+
+from pathlib import Path
+
+import click
+
+
+@click.command(name="molecular-network")
+@click.option(
+    "--model-path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the trained SIMBA model checkpoint (e.g., best_model.ckpt).",
+)
+@click.option(
+    "--input-spectra",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the input spectra file (.mgf format).",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    required=True,
+    help="Directory to save the network and intermediate files.",
+)
+@click.argument("overrides", nargs=-1, type=str)
+def molecular_network(
+    model_path: Path,
+    input_spectra: Path,
+    output_dir: Path,
+    overrides: tuple[str, ...],
+) -> None:
+    """Build a molecular network from a single set of spectra using SIMBA.
+
+    Computes all-vs-all pairwise SIMBA predictions, converts predicted MCES
+    distances to normalized similarities (sim = 1 - mces / max_mces), and
+    outputs a spectral network compatible with Cytoscape and matchms.
+
+    Input spectra are assumed to be deduplicated (one spectrum per compound).
+    Duplicate spectra from the same compound will appear as separate nodes.
+
+    Output files:
+    \b
+      molecular_network.<format>   — spectral network (default: graphml)
+      similarity_mces.npy          — raw MCES distance matrix [N x N], reusable
+                                     via molecular_network.precomputed_mces=<path>
+      network_plot.png             — visualisation (only when molecular_network.plot=true)
+
+    Pass ``molecular_network.precomputed_mces=<path>`` to reuse a previously
+    saved ``similarity_mces.npy`` and skip model inference entirely.
+
+    Examples:
+
+    \b
+    # Basic molecular networking
+    simba molecular-network \\
+        --model-path ./models/best_model.ckpt \\
+        --input-spectra ./data/query.mgf \\
+        --output-dir ./network_output
+
+    \b
+    # Custom score cutoff
+    simba molecular-network \\
+        --model-path ./models/best_model.ckpt \\
+        --input-spectra ./data/query.mgf \\
+        --output-dir ./network_output \\
+        molecular_network.score_cutoff=0.6
+
+    \b
+    # Export as GEXF (e.g. for Gephi)
+    simba molecular-network \\
+        --model-path ./models/best_model.ckpt \\
+        --input-spectra ./data/query.mgf \\
+        --output-dir ./network_output \\
+        molecular_network.graph_format=gexf
+    """
+    from hydra import compose, initialize_config_dir
+    from omegaconf import OmegaConf
+
+    from simba.utils.config_utils import get_config_path
+
+    config_path = get_config_path()
+
+    with initialize_config_dir(config_dir=str(config_path), version_base=None):
+        cfg = compose(config_name="config", overrides=list(overrides))
+
+        model_path = model_path.resolve()
+        input_spectra = input_spectra.resolve()
+        output_dir = output_dir.resolve()
+
+        OmegaConf.set_struct(cfg, False)
+        cfg.paths.model_path = str(model_path)
+        cfg.paths.input_spectra = str(input_spectra)
+        cfg.paths.output_dir = str(output_dir)
+        OmegaConf.set_struct(cfg, True)
+
+        click.echo("=" * 70)
+        click.echo("SIMBA Molecular Networking")
+        click.echo("=" * 70)
+        click.echo(f"\nInput spectra : {input_spectra}")
+        click.echo(f"Model         : {model_path}")
+        click.echo(f"Output dir    : {output_dir}")
+
+        from simba.workflows.molecular_networking import run_molecular_networking
+
+        try:
+            result = run_molecular_networking(cfg)
+        except Exception as exc:
+            click.echo(f"\nError: {exc}", err=True)
+            raise click.Abort() from exc
+
+        click.echo("\n" + "=" * 70)
+        click.echo("DONE")
+        click.echo("=" * 70)
+        click.echo(f"Nodes : {result['n_nodes']}")
+        click.echo(f"Edges : {result['n_edges']}")
+        click.echo(f"Network file : {result['output_file']}")

--- a/simba/configs/config.yaml
+++ b/simba/configs/config.yaml
@@ -7,6 +7,7 @@ defaults:
   - preprocessing: default
   - inference: default
   - analog_discovery: default
+  - molecular_network: default
   - _self_  # Main config applied last, but training configs can override via training=fast_dev
 
 # Project metadata

--- a/simba/configs/molecular_network/default.yaml
+++ b/simba/configs/molecular_network/default.yaml
@@ -1,0 +1,36 @@
+# @package _global_
+
+# Default configuration for molecular networking
+molecular_network:
+  # Device for inference
+  device: cpu  # cpu or gpu
+
+  # GNPS format flag (set true if input MGF uses GNPS-style headers)
+  use_gnps_format: false
+
+  # matchms SimilarityNetwork parameters
+  top_n: 20        # top-N candidates considered per node when adding edges
+  max_links: 10    # maximum edges added per node
+  score_cutoff: 0.5  # minimum similarity to create an edge (0–1)
+  link_method: single  # "single" or "mutual"
+  keep_unconnected_nodes: true  # include isolated nodes in the graph
+
+  # Output format for the network file.
+  # Supported: "graphml" (default), "cyjs", "gexf", "gml", "json"
+  graph_format: graphml
+
+  # Optional: path to a precomputed similarity_mces.npy from a previous run.
+  # When set, the model inference step is skipped entirely.
+  # Example: molecular_network.precomputed_mces=./output/similarity_mces.npy
+  precomputed_mces: null
+
+  # Whether to apply spectrum quality filtering (min peak count, adduct type).
+  # Default false: every spectrum in the file becomes a node.
+  filter_spectra: false
+
+  # Plotting — disabled by default.
+  # Set plot=true to save a network_plot.png alongside the graph file.
+  # plot_label_key: MGF field to use as node labels (e.g. "id", "inchikey").
+  #   When null, node labels are the MGF order index of each spectrum.
+  plot: false
+  plot_label_key: null

--- a/simba/workflows/molecular_networking.py
+++ b/simba/workflows/molecular_networking.py
@@ -132,20 +132,32 @@ def _plot_network(
 
     if len(weights):
         edge_colors = cm.YlOrRd(weights / weights.max())
-        nx.draw_networkx_edges(G, pos, ax=ax, edge_color=edge_colors, alpha=0.6, width=0.8)
+        nx.draw_networkx_edges(
+            G, pos, ax=ax, edge_color=edge_colors, alpha=0.6, width=0.8
+        )
 
     nx.draw_networkx_nodes(
-        G, pos, ax=ax, nodelist=node_list,
-        node_color=node_colors, node_size=node_sizes,
-        linewidths=0.3, edgecolors="white", alpha=0.95,
+        G,
+        pos,
+        ax=ax,
+        nodelist=node_list,
+        node_color=node_colors,
+        node_size=node_sizes,
+        linewidths=0.3,
+        edgecolors="white",
+        alpha=0.95,
     )
-    nx.draw_networkx_labels(G, pos, labels=labels, ax=ax, font_size=4.5, font_color="white")
+    nx.draw_networkx_labels(
+        G, pos, labels=labels, ax=ax, font_size=4.5, font_color="white"
+    )
 
     ax.set_title(
         f"SIMBA Molecular Network\n"
         f"score_cutoff={score_cutoff} · {G.number_of_nodes()} nodes · "
         f"{G.number_of_edges()} edges · {len(components)} clusters",
-        color="white", fontsize=12, pad=14,
+        color="white",
+        fontsize=12,
+        pad=14,
     )
     ax.axis("off")
     plt.tight_layout()
@@ -206,7 +218,9 @@ def run_molecular_networking(cfg: DictConfig) -> dict:
         np.save(output_path + "similarity_mces.npy", sim_mces)
         logger.info(f"Saved raw MCES matrix to {output_path}similarity_mces.npy")
 
-    similarity = mces_to_similarity(sim_mces, mces_max=float(cfg.model.tasks.mces.max_value))
+    similarity = mces_to_similarity(
+        sim_mces, mces_max=float(cfg.model.tasks.mces.max_value)
+    )
     logger.info(
         f"Similarity — min: {similarity.min():.3f}, "
         f"mean: {similarity.mean():.3f}, max: {similarity.max():.3f}"

--- a/simba/workflows/molecular_networking.py
+++ b/simba/workflows/molecular_networking.py
@@ -19,7 +19,7 @@ def mces_to_similarity(mces: np.ndarray, mces_max: float = 40.0) -> np.ndarray:
     return np.clip(1.0 - mces / mces_max, 0.0, 1.0)
 
 
-def _build_scores(node_ids: list[str], similarity_matrix: np.ndarray, score_name: str):
+def _build_scores(spectra: list, similarity_matrix: np.ndarray, score_name: str):
     """Wrap a precomputed [N, N] similarity matrix into a matchms.Scores object."""
     from matchms import Scores, Spectrum
 
@@ -27,10 +27,10 @@ def _build_scores(node_ids: list[str], similarity_matrix: np.ndarray, score_name
         Spectrum(
             mz=np.array([], dtype=float),
             intensities=np.array([], dtype=float),
-            metadata={"spectrum_id": nid},
+            metadata={"spectrum_id": str(s.mgf_index)},
             metadata_harmonization=False,
         )
-        for nid in node_ids
+        for s in spectra
     ]
     scores = Scores(references=nodes, queries=nodes, is_symmetric=True)
     scores._scores.add_dense_matrix(similarity_matrix.T, score_name)
@@ -99,7 +99,7 @@ def _plot_network(
         row_extents = comp_extents[row_slice]
         row_height = max(row_extents) * 2 + PADDING
         x_cursor = 0.0
-        for comp, lpos, extent in zip(row_comps, row_layouts, row_extents):
+        for _comp, lpos, extent in zip(row_comps, row_layouts, row_extents):
             offset = np.array([x_cursor + extent, -y_cursor - extent])
             for nd, p in lpos.items():
                 pos[nd] = p + offset
@@ -191,8 +191,6 @@ def run_molecular_networking(cfg: DictConfig) -> dict:
         )
     logger.info(f"Loaded {len(all_spectra)} spectra.")
 
-    node_ids = [str(s.mgf_index) for s in all_spectra]
-
     precomputed = mn_cfg.precomputed_mces
     if precomputed:
         logger.info(f"Loading precomputed MCES from {precomputed}")
@@ -215,7 +213,7 @@ def run_molecular_networking(cfg: DictConfig) -> dict:
     )
 
     score_name = "simba_similarity"
-    scores, _ = _build_scores(node_ids, similarity, score_name)
+    scores, _ = _build_scores(all_spectra, similarity, score_name)
 
     network = SimilarityNetwork(
         identifier_key="spectrum_id",

--- a/simba/workflows/molecular_networking.py
+++ b/simba/workflows/molecular_networking.py
@@ -1,0 +1,262 @@
+"""Workflow for molecular networking using SIMBA predictions."""
+
+import os
+from pathlib import Path
+
+import numpy as np
+from omegaconf import DictConfig
+
+from simba.core.models.simba_model import Simba
+from simba.utils.logger_setup import logger
+from simba.workflows.utils import load_spectra
+
+
+def mces_to_similarity(mces: np.ndarray, mces_max: float = 40.0) -> np.ndarray:
+    """Convert an [N, N] MCES distance matrix to similarity scores in [0, 1].
+
+    Uses ``sim = 1 - mces / mces_max``.
+    """
+    return np.clip(1.0 - mces / mces_max, 0.0, 1.0)
+
+
+def _build_scores(node_ids: list[str], similarity_matrix: np.ndarray, score_name: str):
+    """Wrap a precomputed [N, N] similarity matrix into a matchms.Scores object."""
+    from matchms import Scores, Spectrum
+
+    nodes = [
+        Spectrum(
+            mz=np.array([], dtype=float),
+            intensities=np.array([], dtype=float),
+            metadata={"spectrum_id": nid},
+            metadata_harmonization=False,
+        )
+        for nid in node_ids
+    ]
+    scores = Scores(references=nodes, queries=nodes, is_symmetric=True)
+    scores._scores.add_dense_matrix(similarity_matrix.T, score_name)
+    return scores, nodes
+
+
+def _plot_network(
+    graph_path: str,
+    label_key: str | None = None,
+    score_cutoff: float = 0.0,
+) -> None:
+    """Load ``graph_path`` (GraphML) and render it to ``network_plot.png`` in the same directory."""
+    import math
+
+    import matplotlib
+    import matplotlib.cm as cm
+    import matplotlib.pyplot as plt
+    import networkx as nx
+
+    matplotlib.use("Agg")
+
+    G = nx.read_graphml(graph_path)
+
+    output_path = str(Path(graph_path).parent / "network_plot.png")
+
+    components = sorted(nx.connected_components(G), key=len, reverse=True)
+    component_map = {n: i for i, comp in enumerate(components) for n in comp}
+    PADDING = 1.5
+    cols = math.ceil(math.sqrt(len(components)))
+
+    comp_layouts: list[dict] = []
+    comp_extents: list[float] = []
+    for comp in components:
+        sub = G.subgraph(comp)
+        n = len(comp)
+        if n == 1:
+            (nd,) = comp
+            lpos: dict = {nd: np.zeros(2)}
+            extent = 0.5
+        elif n == 2:
+            ns = list(comp)
+            lpos = {ns[0]: np.array([-0.5, 0.0]), ns[1]: np.array([0.5, 0.0])}
+            extent = 0.8
+        else:
+            lpos = nx.kamada_kawai_layout(sub)
+            # Normalise to unit circle so scale factor is consistent
+            arr = np.array(list(lpos.values()))
+            center = arr.mean(axis=0)
+            lpos = {nd: np.array(p) - center for nd, p in lpos.items()}
+            max_r = max(np.linalg.norm(p) for p in lpos.values()) or 1.0
+            lpos = {nd: p / max_r for nd, p in lpos.items()}
+            extent = 1.0
+        # Scale so that the cluster footprint grows with sqrt(n)
+        scale = max(1.0, math.sqrt(n))
+        lpos = {nd: p * scale for nd, p in lpos.items()}
+        comp_layouts.append(lpos)
+        comp_extents.append(extent * scale)
+
+    # Pack rows left-to-right with variable-size cells
+    pos: dict = {}
+    y_cursor = 0.0
+    for ri in range(math.ceil(len(components) / cols)):
+        row_slice = slice(ri * cols, (ri + 1) * cols)
+        row_comps = components[row_slice]
+        row_layouts = comp_layouts[row_slice]
+        row_extents = comp_extents[row_slice]
+        row_height = max(row_extents) * 2 + PADDING
+        x_cursor = 0.0
+        for comp, lpos, extent in zip(row_comps, row_layouts, row_extents):
+            offset = np.array([x_cursor + extent, -y_cursor - extent])
+            for nd, p in lpos.items():
+                pos[nd] = p + offset
+            x_cursor += extent * 2 + PADDING
+        y_cursor += row_height
+
+    node_list = list(G.nodes())
+    node_colors = [cm.tab20(component_map[n] % 20) for n in node_list]
+    degrees = dict(G.degree())
+    # Shrink nodes in large clusters so they don't overlap
+    comp_size_map = {nd: len(comp) for comp in components for nd in comp}
+    node_sizes = [
+        max(15, 60 / max(1.0, math.sqrt(comp_size_map[nd])) + degrees[nd] * 4)
+        for nd in node_list
+    ]
+    weights = (
+        np.array([d["weight"] for _, _, d in G.edges(data=True)])
+        if G.number_of_edges()
+        else np.array([])
+    )
+
+    if label_key:
+        labels = {n: G.nodes[n].get(label_key, n) for n in node_list}
+    else:
+        labels = {n: n for n in node_list}
+
+    fig, ax = plt.subplots(figsize=(22, 18))
+    ax.set_facecolor("#111318")
+    fig.patch.set_facecolor("#111318")
+
+    if len(weights):
+        edge_colors = cm.YlOrRd(weights / weights.max())
+        nx.draw_networkx_edges(G, pos, ax=ax, edge_color=edge_colors, alpha=0.6, width=0.8)
+
+    nx.draw_networkx_nodes(
+        G, pos, ax=ax, nodelist=node_list,
+        node_color=node_colors, node_size=node_sizes,
+        linewidths=0.3, edgecolors="white", alpha=0.95,
+    )
+    nx.draw_networkx_labels(G, pos, labels=labels, ax=ax, font_size=4.5, font_color="white")
+
+    ax.set_title(
+        f"SIMBA Molecular Network\n"
+        f"score_cutoff={score_cutoff} · {G.number_of_nodes()} nodes · "
+        f"{G.number_of_edges()} edges · {len(components)} clusters",
+        color="white", fontsize=12, pad=14,
+    )
+    ax.axis("off")
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close()
+
+
+def run_molecular_networking(cfg: DictConfig) -> dict:
+    """Run molecular networking workflow.
+
+    Loads a set of spectra, runs all-vs-all SIMBA predictions, converts the
+    predicted MCES distances to normalised similarity scores, and builds a
+    spectral network using ``matchms.networking.SimilarityNetwork``.
+
+    Args:
+        cfg: Hydra configuration object with paths and molecular_network settings.
+
+    Returns:
+        Dictionary with keys ``"output_dir"``, ``"n_nodes"``, ``"n_edges"``,
+        ``"output_file"``.
+    """
+    from matchms.networking import SimilarityNetwork
+
+    output_dir = Path(cfg.paths.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = str(output_dir) + os.sep
+
+    mn_cfg = cfg.molecular_network
+
+    if mn_cfg.filter_spectra:
+        all_spectra = load_spectra(
+            str(cfg.paths.input_spectra),
+            cfg,
+            use_gnps_format=mn_cfg.use_gnps_format,
+        )
+    else:
+        all_spectra = load_spectra(
+            str(cfg.paths.input_spectra),
+            cfg,
+            use_gnps_format=mn_cfg.use_gnps_format,
+            min_peaks=0,
+            use_only_protonized_adducts=False,
+        )
+    logger.info(f"Loaded {len(all_spectra)} spectra.")
+
+    node_ids = [str(s.mgf_index) for s in all_spectra]
+
+    precomputed = mn_cfg.precomputed_mces
+    if precomputed:
+        logger.info(f"Loading precomputed MCES from {precomputed}")
+        sim_mces = np.load(precomputed)
+    else:
+        simba_model = Simba(
+            str(cfg.paths.model_path),
+            config=cfg,
+            device=mn_cfg.device,
+            cache_embeddings=True,
+        )
+        _, sim_mces = simba_model.predict(all_spectra, all_spectra)
+        np.save(output_path + "similarity_mces.npy", sim_mces)
+        logger.info(f"Saved raw MCES matrix to {output_path}similarity_mces.npy")
+
+    similarity = mces_to_similarity(sim_mces, mces_max=float(cfg.model.tasks.mces.max_value))
+    logger.info(
+        f"Similarity — min: {similarity.min():.3f}, "
+        f"mean: {similarity.mean():.3f}, max: {similarity.max():.3f}"
+    )
+
+    score_name = "simba_similarity"
+    scores, _ = _build_scores(node_ids, similarity, score_name)
+
+    network = SimilarityNetwork(
+        identifier_key="spectrum_id",
+        top_n=mn_cfg.top_n,
+        max_links=mn_cfg.max_links,
+        score_cutoff=mn_cfg.score_cutoff,
+        link_method=mn_cfg.link_method,
+        keep_unconnected_nodes=mn_cfg.keep_unconnected_nodes,
+    )
+    network.create_network(scores, score_name=score_name)
+    G = network.graph
+
+    # Annotate ALL metadata fields from each spectrum onto the graph node so
+    # the exported GraphML is self-contained (readable in Cytoscape, etc.).
+    for s in all_spectra:
+        nid = str(s.mgf_index)
+        if nid in G:
+            for key, val in s.params.items():
+                if val is not None:
+                    G.nodes[nid][key] = str(val)
+
+    plot_label_key = mn_cfg.plot_label_key
+    n_nodes = G.number_of_nodes()
+    n_edges = G.number_of_edges()
+    logger.info(f"Network: {n_nodes} nodes, {n_edges} edges.")
+
+    graph_format = mn_cfg.graph_format
+    output_file = output_path + f"molecular_network.{graph_format}"
+    network.export_to_file(output_file, graph_format=graph_format)
+    logger.info(f"Saved to {output_file}")
+
+    if mn_cfg.plot:
+        _plot_network(
+            graph_path=output_file,
+            label_key=plot_label_key,
+            score_cutoff=mn_cfg.score_cutoff,
+        )
+
+    return {
+        "output_dir": str(output_dir),
+        "n_nodes": n_nodes,
+        "n_edges": n_edges,
+        "output_file": output_file,
+    }

--- a/test_all_commands.sh
+++ b/test_all_commands.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Test script for all SIMBA commands
-# Tests: preprocess, sweep (fresh+resume), train, inference, analog-discovery
+# Tests: preprocess, sweep (fresh+resume), train, inference, analog-discovery, molecular-network
 #
 # Usage: bash test_all_commands.sh [DEVICE] [PRETRAINED_CHECKPOINT_DIR] [PRETRAINED_MODEL_NAME]
 #   DEVICE: cpu or gpu (default: cpu)
@@ -44,7 +44,7 @@ rm -rf test_full_workflow/
 mkdir -p test_full_workflow
 
 echo ""
-echo "1/10 Testing: simba preprocess"
+echo "1/14 Testing: simba preprocess"
 echo "--------------------------------"
 uv run simba preprocess \
     preprocessing=fast_dev \
@@ -52,7 +52,7 @@ uv run simba preprocess \
     paths.preprocessing_dir=./test_full_workflow/preprocessed/
 
 echo ""
-echo "2/10 Testing: simba preprocess with cache (reuse distances)"
+echo "2/14 Testing: simba preprocess with cache (reuse distances)"
 echo "------------------------------------------------------------"
 uv run simba preprocess \
     preprocessing=fast_dev \
@@ -61,7 +61,7 @@ uv run simba preprocess \
     'preprocessing.precomputed_distances=[./test_full_workflow/preprocessed/]'
 
 echo ""
-echo "3/12 Testing: simba-sweep (fresh, 3 trials, 1 epoch)"
+echo "3/14 Testing: simba-sweep (fresh, 3 trials, 1 epoch)"
 echo "------------------------------------------------------------"
 uv run simba-sweep \
     +sweep=default \
@@ -73,7 +73,7 @@ uv run simba-sweep \
     hardware.accelerator=$DEVICE
 
 echo ""
-echo "4/12 Testing: simba-sweep (resume, 3 more trials with prior TPE knowledge)"
+echo "4/14 Testing: simba-sweep (resume, 3 more trials with prior TPE knowledge)"
 echo "------------------------------------------------------------"
 uv run simba-sweep \
     +sweep=default \
@@ -85,7 +85,7 @@ uv run simba-sweep \
     hardware.accelerator=$DEVICE
 
 echo ""
-echo "5/12 Testing: simba train"
+echo "5/14 Testing: simba train"
 echo "--------------------------------"
 uv run simba train \
     training=fast_dev \
@@ -96,7 +96,7 @@ uv run simba train \
     hardware.accelerator=$DEVICE
 
 echo ""
-echo "6/12 Testing: simba inference"
+echo "6/14 Testing: simba inference"
 echo "--------------------------------"
 uv run simba inference \
     inference=fast_dev \
@@ -106,7 +106,7 @@ uv run simba inference \
     hardware.accelerator=$DEVICE
 
 echo ""
-echo "7/12 Testing: simba analog-discovery"
+echo "7/14 Testing: simba analog-discovery"
 echo "--------------------------------"
 uv run simba analog-discovery \
     analog_discovery=fast_dev \
@@ -119,7 +119,7 @@ uv run simba analog-discovery \
 
 if [[ "$SKIP_PRETRAINED" == "false" ]]; then
     echo ""
-    echo "8/12 Testing: simba inference (pretrained model)"
+    echo "8/14 Testing: simba inference (pretrained model)"
     echo "--------------------------------"
     uv run simba inference \
         inference=fast_dev \
@@ -129,7 +129,7 @@ if [[ "$SKIP_PRETRAINED" == "false" ]]; then
         hardware.accelerator=$DEVICE
 
     echo ""
-    echo "9/12 Testing: simba analog-discovery (pretrained model)"
+    echo "9/14 Testing: simba analog-discovery (pretrained model)"
     echo "--------------------------------"
     uv run simba analog-discovery \
         analog_discovery=fast_dev \
@@ -141,13 +141,13 @@ if [[ "$SKIP_PRETRAINED" == "false" ]]; then
         analog_discovery.device=$DEVICE
 else
     echo ""
-    echo "8/12 Skipping: simba inference (pretrained model) - no pretrained model provided"
+    echo "8/14 Skipping: simba inference (pretrained model) - no pretrained model provided"
     echo ""
-    echo "9/12 Skipping: simba analog-discovery (pretrained model) - no pretrained model provided"
+    echo "9/14 Skipping: simba analog-discovery (pretrained model) - no pretrained model provided"
 fi
 
 echo ""
-echo "10/12 Testing: simba train (with metadata features)"
+echo "10/14 Testing: simba train (with metadata features)"
 echo "--------------------------------"
 uv run simba train \
     training=fast_dev \
@@ -162,7 +162,7 @@ uv run simba train \
     hardware.accelerator=$DEVICE
 
 echo ""
-echo "11/12 Testing: simba inference (with metadata features)"
+echo "11/14 Testing: simba inference (with metadata features)"
 echo "--------------------------------"
 uv run simba inference \
     inference=fast_dev \
@@ -176,7 +176,7 @@ uv run simba inference \
     hardware.accelerator=$DEVICE
 
 echo ""
-echo "12/12 Testing: simba analog-discovery (with metadata features)"
+echo "12/14 Testing: simba analog-discovery (with metadata features)"
 echo "--------------------------------"
 uv run simba analog-discovery \
     analog_discovery=fast_dev \
@@ -190,6 +190,27 @@ uv run simba analog-discovery \
     model.features.use_ion_activation=true \
     model.features.use_ion_method=true \
     analog_discovery.device=$DEVICE
+
+echo ""
+echo "13/14 Testing: simba molecular-network (from scratch)"
+echo "--------------------------------"
+uv run simba molecular-network \
+    --model-path ./test_full_workflow/checkpoints/best_model.ckpt \
+    --input-spectra data/casmi2022.mgf \
+    --output-dir ./test_full_workflow/molecular_network/ \
+    molecular_network.device=$DEVICE \
+    molecular_network.score_cutoff=0.0
+
+echo ""
+echo "14/14 Testing: simba molecular-network (reuse precomputed MCES)"
+echo "--------------------------------"
+uv run simba molecular-network \
+    --model-path ./test_full_workflow/checkpoints/best_model.ckpt \
+    --input-spectra data/casmi2022.mgf \
+    --output-dir ./test_full_workflow/molecular_network_precomputed/ \
+    molecular_network.device=$DEVICE \
+    molecular_network.score_cutoff=0.0 \
+    molecular_network.precomputed_mces=./test_full_workflow/molecular_network/similarity_mces.npy
 
 echo ""
 echo "================================"

--- a/tests/integration/test_molecular_networking.py
+++ b/tests/integration/test_molecular_networking.py
@@ -1,0 +1,107 @@
+"""Integration tests for SIMBA molecular networking."""
+
+import numpy as np
+import pytest
+
+from simba.core.models.simba_model import Simba
+from simba.workflows.molecular_networking import (
+    _build_scores,
+    mces_to_similarity,
+)
+from simba.workflows.utils import load_spectra
+
+
+pytestmark = pytest.mark.integration
+
+
+class TestMolecularNetworkingWorkflow:
+    def test_all_vs_all_prediction_shape(self, sample_mgf_casmi, mock_model, hydra_config):
+        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+        assert len(spectra) >= 2
+
+        simba = Simba("fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True)
+        sim_ed, sim_mces = simba.predict(spectra, spectra)
+
+        n = len(spectra)
+        assert sim_ed.shape == (n, n)
+        assert sim_mces.shape == (n, n)
+
+    def test_embedding_cached_for_symmetric_call(self, sample_mgf_casmi, mock_model, hydra_config):
+        """Second predict call with the same spectra should hit the cache."""
+        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+        simba = Simba("fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True)
+
+        simba.predict(spectra, spectra)
+        initial_cache_size = len(simba._embedding_cache)
+
+        simba.predict(spectra, spectra)
+        assert len(simba._embedding_cache) == initial_cache_size
+
+    def test_similarity_matrix_in_unit_interval(self, sample_mgf_casmi, mock_model, hydra_config):
+        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+        simba = Simba("fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True)
+        _, sim_mces = simba.predict(spectra, spectra)
+
+        similarity = mces_to_similarity(sim_mces)
+
+        assert np.all(similarity >= 0.0)
+        assert np.all(similarity <= 1.0)
+
+    def test_matchms_scores_wrapper(self, sample_mgf_casmi, mock_model, hydra_config):
+        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+        n = len(spectra)
+        sim = np.ones((n, n)) * 0.8
+        node_ids = [str(i) for i in range(len(spectra))]
+        scores, nodes = _build_scores(node_ids, sim, "simba_similarity")
+
+        assert scores.n_rows == n
+        assert scores.n_cols == n
+        assert len(nodes) == n
+        assert all(node.get("spectrum_id") is not None for node in nodes)
+
+    def test_network_has_nodes_and_edges(self, sample_mgf_casmi, mock_model, hydra_config):
+        from matchms.networking import SimilarityNetwork
+
+        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+        simba = Simba("fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True)
+        _, sim_mces = simba.predict(spectra, spectra)
+
+        similarity = mces_to_similarity(sim_mces)
+        node_ids = [str(i) for i in range(len(spectra))]
+        scores, _ = _build_scores(node_ids, similarity, "simba_similarity")
+
+        network = SimilarityNetwork(
+            identifier_key="spectrum_id",
+            top_n=len(spectra),
+            max_links=len(spectra) - 1,
+            score_cutoff=0.0,
+        )
+        network.create_network(scores, score_name="simba_similarity")
+
+        assert network.graph.number_of_nodes() == len(spectra)
+        assert network.graph.number_of_edges() >= 0
+
+    def test_network_export_graphml(self, sample_mgf_casmi, mock_model, hydra_config, temp_dir):
+        from matchms.networking import SimilarityNetwork
+
+        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+        n = len(spectra)
+        sim = np.ones((n, n)) * 0.9
+        np.fill_diagonal(sim, 1.0)
+
+        scores, _ = _build_scores(
+            [str(i) for i in range(len(spectra))],
+            sim, "simba_similarity"
+        )
+        network = SimilarityNetwork(
+            identifier_key="spectrum_id",
+            top_n=n,
+            max_links=n - 1,
+            score_cutoff=0.5,
+        )
+        network.create_network(scores, score_name="simba_similarity")
+
+        output_file = str(temp_dir / "network.graphml")
+        network.export_to_file(output_file, graph_format="graphml")
+
+        assert (temp_dir / "network.graphml").exists()

--- a/tests/integration/test_molecular_networking.py
+++ b/tests/integration/test_molecular_networking.py
@@ -15,21 +15,33 @@ pytestmark = pytest.mark.integration
 
 
 class TestMolecularNetworkingWorkflow:
-    def test_all_vs_all_prediction_shape(self, sample_mgf_casmi, mock_model, hydra_config):
-        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+    def test_all_vs_all_prediction_shape(
+        self, sample_mgf_casmi, mock_model, hydra_config
+    ):
+        spectra = load_spectra(
+            sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100
+        )
         assert len(spectra) >= 2
 
-        simba = Simba("fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True)
+        simba = Simba(
+            "fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True
+        )
         sim_ed, sim_mces = simba.predict(spectra, spectra)
 
         n = len(spectra)
         assert sim_ed.shape == (n, n)
         assert sim_mces.shape == (n, n)
 
-    def test_embedding_cached_for_symmetric_call(self, sample_mgf_casmi, mock_model, hydra_config):
+    def test_embedding_cached_for_symmetric_call(
+        self, sample_mgf_casmi, mock_model, hydra_config
+    ):
         """Second predict call with the same spectra should hit the cache."""
-        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
-        simba = Simba("fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True)
+        spectra = load_spectra(
+            sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100
+        )
+        simba = Simba(
+            "fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True
+        )
 
         simba.predict(spectra, spectra)
         initial_cache_size = len(simba._embedding_cache)
@@ -37,9 +49,15 @@ class TestMolecularNetworkingWorkflow:
         simba.predict(spectra, spectra)
         assert len(simba._embedding_cache) == initial_cache_size
 
-    def test_similarity_matrix_in_unit_interval(self, sample_mgf_casmi, mock_model, hydra_config):
-        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
-        simba = Simba("fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True)
+    def test_similarity_matrix_in_unit_interval(
+        self, sample_mgf_casmi, mock_model, hydra_config
+    ):
+        spectra = load_spectra(
+            sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100
+        )
+        simba = Simba(
+            "fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True
+        )
         _, sim_mces = simba.predict(spectra, spectra)
 
         similarity = mces_to_similarity(sim_mces)
@@ -48,7 +66,9 @@ class TestMolecularNetworkingWorkflow:
         assert np.all(similarity <= 1.0)
 
     def test_matchms_scores_wrapper(self, sample_mgf_casmi, mock_model, hydra_config):
-        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+        spectra = load_spectra(
+            sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100
+        )
         n = len(spectra)
         sim = np.ones((n, n)) * 0.8
         scores, nodes = _build_scores(spectra, sim, "simba_similarity")
@@ -58,11 +78,17 @@ class TestMolecularNetworkingWorkflow:
         assert len(nodes) == n
         assert all(node.get("spectrum_id") is not None for node in nodes)
 
-    def test_network_has_nodes_and_edges(self, sample_mgf_casmi, mock_model, hydra_config):
+    def test_network_has_nodes_and_edges(
+        self, sample_mgf_casmi, mock_model, hydra_config
+    ):
         from matchms.networking import SimilarityNetwork
 
-        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
-        simba = Simba("fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True)
+        spectra = load_spectra(
+            sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100
+        )
+        simba = Simba(
+            "fake_model.ckpt", config=hydra_config, device="cpu", cache_embeddings=True
+        )
         _, sim_mces = simba.predict(spectra, spectra)
 
         similarity = mces_to_similarity(sim_mces)
@@ -79,10 +105,14 @@ class TestMolecularNetworkingWorkflow:
         assert network.graph.number_of_nodes() == len(spectra)
         assert network.graph.number_of_edges() >= 0
 
-    def test_network_export_graphml(self, sample_mgf_casmi, mock_model, hydra_config, temp_dir):
+    def test_network_export_graphml(
+        self, sample_mgf_casmi, mock_model, hydra_config, temp_dir
+    ):
         from matchms.networking import SimilarityNetwork
 
-        spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
+        spectra = load_spectra(
+            sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100
+        )
         n = len(spectra)
         sim = np.ones((n, n)) * 0.9
         np.fill_diagonal(sim, 1.0)

--- a/tests/integration/test_molecular_networking.py
+++ b/tests/integration/test_molecular_networking.py
@@ -51,8 +51,7 @@ class TestMolecularNetworkingWorkflow:
         spectra = load_spectra(sample_mgf_casmi, hydra_config, min_peaks=5, n_samples=100)
         n = len(spectra)
         sim = np.ones((n, n)) * 0.8
-        node_ids = [str(i) for i in range(len(spectra))]
-        scores, nodes = _build_scores(node_ids, sim, "simba_similarity")
+        scores, nodes = _build_scores(spectra, sim, "simba_similarity")
 
         assert scores.n_rows == n
         assert scores.n_cols == n
@@ -67,8 +66,7 @@ class TestMolecularNetworkingWorkflow:
         _, sim_mces = simba.predict(spectra, spectra)
 
         similarity = mces_to_similarity(sim_mces)
-        node_ids = [str(i) for i in range(len(spectra))]
-        scores, _ = _build_scores(node_ids, similarity, "simba_similarity")
+        scores, _ = _build_scores(spectra, similarity, "simba_similarity")
 
         network = SimilarityNetwork(
             identifier_key="spectrum_id",
@@ -89,10 +87,7 @@ class TestMolecularNetworkingWorkflow:
         sim = np.ones((n, n)) * 0.9
         np.fill_diagonal(sim, 1.0)
 
-        scores, _ = _build_scores(
-            [str(i) for i in range(len(spectra))],
-            sim, "simba_similarity"
-        )
+        scores, _ = _build_scores(spectra, sim, "simba_similarity")
         network = SimilarityNetwork(
             identifier_key="spectrum_id",
             top_n=n,

--- a/tests/unit/test_molecular_networking.py
+++ b/tests/unit/test_molecular_networking.py
@@ -1,0 +1,90 @@
+"""Unit tests for SIMBA molecular networking."""
+
+import numpy as np
+import pytest
+
+from simba.workflows.molecular_networking import (
+    _build_scores,
+    mces_to_similarity,
+)
+
+
+class TestMcesToSimilarity:
+    def test_fixed_normalization_zero_distance(self):
+        mces = np.zeros((3, 3))
+        result = mces_to_similarity(mces)
+        np.testing.assert_array_equal(result, np.ones((3, 3)))
+
+    def test_fixed_normalization_max_distance(self):
+        mces = np.full((2, 2), 20.0)
+        result = mces_to_similarity(mces, mces_max=20.0)
+        np.testing.assert_array_almost_equal(result, np.zeros((2, 2)))
+
+    def test_fixed_normalization_clamps_below_zero(self):
+        mces = np.array([[25.0]])
+        result = mces_to_similarity(mces, mces_max=20.0)
+        assert result[0, 0] == 0.0
+
+    def test_fixed_normalization_midpoint(self):
+        mces = np.array([[10.0]])
+        result = mces_to_similarity(mces, mces_max=20.0)
+        assert result[0, 0] == pytest.approx(0.5)
+
+    def test_fixed_normalization_custom_max(self):
+        mces = np.array([[5.0]])
+        result = mces_to_similarity(mces, mces_max=10.0)
+        assert result[0, 0] == pytest.approx(0.5)
+
+    def test_output_always_in_unit_interval(self):
+        rng = np.random.default_rng(42)
+        mces = rng.uniform(0, 30, (10, 10))
+        result = mces_to_similarity(mces)
+        assert np.all(result >= 0.0)
+        assert np.all(result <= 1.0)
+
+    def test_symmetric_input_gives_symmetric_output(self):
+        rng = np.random.default_rng(0)
+        m = rng.uniform(0, 20, (5, 5))
+        sym = (m + m.T) / 2
+        result = mces_to_similarity(sym)
+        np.testing.assert_array_almost_equal(result, result.T)
+
+
+class TestBuildScores:
+    def test_build_scores_shape(self, create_test_spectrum):
+        spectra = [create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10)) for i in range(4)]
+        sim = np.eye(4)
+        scores, nodes = _build_scores(spectra, sim, "simba_similarity")
+
+        assert len(nodes) == 4
+        assert scores.n_rows == 4
+        assert scores.n_cols == 4
+
+    def test_node_ids_are_mgf_position(self, create_test_spectrum):
+        spectra = [create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10)) for i in range(3)]
+        scores, nodes = _build_scores(spectra, np.eye(3), "simba_similarity")
+        assert [n.get("spectrum_id") for n in nodes] == ["0", "1", "2"]
+
+    def test_node_ids_use_mgf_index_not_list_position(self, create_test_spectrum):
+        # Simulate 3 spectra surviving filtering from a larger MGF (indices 5, 7, 9)
+        spectra = [create_test_spectrum(mgf_index=2 * i + 5, precursor_mz=float(100 + i * 10)) for i in range(3)]
+        scores, nodes = _build_scores(spectra, np.eye(3), "simba_similarity")
+        assert [n.get("spectrum_id") for n in nodes] == ["5", "7", "9"]
+
+    def test_network_builds_from_scores(self, create_test_spectrum):
+        from matchms.networking import SimilarityNetwork
+
+        spectra = [create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10)) for i in range(4)]
+        sim = np.ones((4, 4)) * 0.9
+        np.fill_diagonal(sim, 1.0)
+        scores, _ = _build_scores(spectra, sim, "simba_similarity")
+
+        network = SimilarityNetwork(
+            identifier_key="spectrum_id",
+            top_n=4,
+            max_links=3,
+            score_cutoff=0.5,
+        )
+        network.create_network(scores, score_name="simba_similarity")
+        assert network.graph.number_of_nodes() == 4
+        assert network.graph.number_of_edges() > 0

--- a/tests/unit/test_molecular_networking.py
+++ b/tests/unit/test_molecular_networking.py
@@ -52,7 +52,10 @@ class TestMcesToSimilarity:
 
 class TestBuildScores:
     def test_build_scores_shape(self, create_test_spectrum):
-        spectra = [create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10)) for i in range(4)]
+        spectra = [
+            create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10))
+            for i in range(4)
+        ]
         sim = np.eye(4)
         scores, nodes = _build_scores(spectra, sim, "simba_similarity")
 
@@ -61,20 +64,29 @@ class TestBuildScores:
         assert scores.n_cols == 4
 
     def test_node_ids_are_mgf_position(self, create_test_spectrum):
-        spectra = [create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10)) for i in range(3)]
+        spectra = [
+            create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10))
+            for i in range(3)
+        ]
         scores, nodes = _build_scores(spectra, np.eye(3), "simba_similarity")
         assert [n.get("spectrum_id") for n in nodes] == ["0", "1", "2"]
 
     def test_node_ids_use_mgf_index_not_list_position(self, create_test_spectrum):
         # Simulate 3 spectra surviving filtering from a larger MGF (indices 5, 7, 9)
-        spectra = [create_test_spectrum(mgf_index=2 * i + 5, precursor_mz=float(100 + i * 10)) for i in range(3)]
+        spectra = [
+            create_test_spectrum(mgf_index=2 * i + 5, precursor_mz=float(100 + i * 10))
+            for i in range(3)
+        ]
         scores, nodes = _build_scores(spectra, np.eye(3), "simba_similarity")
         assert [n.get("spectrum_id") for n in nodes] == ["5", "7", "9"]
 
     def test_network_builds_from_scores(self, create_test_spectrum):
         from matchms.networking import SimilarityNetwork
 
-        spectra = [create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10)) for i in range(4)]
+        spectra = [
+            create_test_spectrum(mgf_index=i, precursor_mz=float(100 + i * 10))
+            for i in range(4)
+        ]
         sim = np.ones((4, 4)) * 0.9
         np.fill_diagonal(sim, 1.0)
         scores, _ = _build_scores(spectra, sim, "simba_similarity")


### PR DESCRIPTION
This pull request adds support for molecular networking to SIMBA, enabling users to compute and visualize all-vs-all spectral similarity networks using SIMBA's learned structural distance predictions. The changes introduce a new CLI command, configuration, workflow, and documentation for this feature, as well as updates to the test script to ensure coverage. Below are the most important changes grouped by theme:

**New Feature: Molecular Networking**

* Added a new CLI command `molecular-network` (`simba/commands/molecular_networking.py`) that generates a spectral network from a set of spectra using SIMBA's MCES-based similarity predictions. The command supports various configuration options and outputs results compatible with Cytoscape and matchms.
* Implemented the molecular networking workflow (`simba/workflows/molecular_networking.py`), including all-vs-all MCES prediction, similarity normalization, network construction with matchms, and optional plotting of the resulting network.
* Added a default configuration for molecular networking (`simba/configs/molecular_network/default.yaml`) with parameters for device selection, filtering, output format, and more.
* Registered the new command and configuration in the CLI and main config (`simba/cli.py`, `simba/configs/config.yaml`). [[1]](diffhunk://#diff-027b3675ee2783a955c37c699f2d083424785bf2845df061818b7067d69568e9R7) [[2]](diffhunk://#diff-027b3675ee2783a955c37c699f2d083424785bf2845df061818b7067d69568e9R26) [[3]](diffhunk://#diff-381d6cc1dec89a86b36171c704634ff024d64b69c325b5b664a9fa2cf55258a0R10)

**Documentation & Testing**

* Updated the `README.md` with a new section explaining molecular networking, usage examples, parameter descriptions, and output interpretation.
* Extended the test script (`test_all_commands.sh`) to include the new molecular-network command, ensuring it is tested alongside existing functionality. [[1]](diffhunk://#diff-361868973a2555f2ccf8d301e196ef7dcb628302d8b882c738b46779603c24f6L4-R4) [[2]](diffhunk://#diff-361868973a2555f2ccf8d301e196ef7dcb628302d8b882c738b46779603c24f6L47-R55) [[3]](diffhunk://#diff-361868973a2555f2ccf8d301e196ef7dcb628302d8b882c738b46779603c24f6L64-R64) [[4]](diffhunk://#diff-361868973a2555f2ccf8d301e196ef7dcb628302d8b882c738b46779603c24f6L76-R76) [[5]](diffhunk://#diff-361868973a2555f2ccf8d301e196ef7dcb628302d8b882c738b46779603c24f6L88-R88) [[6]](diffhunk://#diff-361868973a2555f2ccf8d301e196ef7dcb628302d8b882c738b46779603c24f6L99-R99) [[7]](diffhunk://#diff-361868973a2555f2ccf8d301e196ef7dcb628302d8b882c738b46779603c24f6L109-R109) [[8]](diffhunk://#diff-361868973a2555f2ccf8d301e196ef7dcb628302d8b882c738b46779603c24f6L122-R122)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added molecular networking capability to generate similarity networks from spectra using trained SIMBA models or precomputed similarity matrices.
  * New CLI command: `simba molecular-network` with options for model path, input spectra, and output directory.

* **Documentation**
  * Added “Molecular Networking Using SIMBA” guide with CLI examples, configuration options, output descriptions, normalization details, and Python loading snippet.

* **Tests**
  * Added unit and integration tests covering normalization, score wrapping, caching, network construction, and GraphML export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->