### PR TITLE
Refactor spectrum_vector code, fix imports, and upgrade dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "hydra-optuna-sweeper>=1.2.0",
     "hydra-submitit-launcher>=1.2.0",
     "optuna>=2.10.1",
-    "metabo-depthcharge",
+    "metabo-depthcharge @ git+https://github.com/bittremieuxlab/metabo-depthcharge.git",
 ]
 
 [project.optional-dependencies]
@@ -228,9 +228,6 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
 ]
-
-[tool.uv.sources]
-metabo-depthcharge = { git = "https://github.com/bittremieuxlab/metabo-depthcharge.git" }
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,7 +230,7 @@ exclude_lines = [
 ]
 
 [tool.uv.sources]
-metabo-depthcharge = { path = "../metabo-depthcharge", editable = true }
+metabo-depthcharge = { git = "https://github.com/bittremieuxlab/metabo-depthcharge.git" }
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "matchms>=0.24.0",
     "spectrum-utils>=0.4.0",
     "pyteomics>=4.6.0",
-    "depthcharge-ms @ git+https://github.com/wfondrie/depthcharge.git@bd2861f",
+    "depthcharge-ms>=0.4.9",
     "myopic-mces>=1.0.0,<2.0.0",
     "highspy>=1.13.1",
     # Data processing
@@ -69,6 +69,7 @@ dependencies = [
     "hydra-optuna-sweeper>=1.2.0",
     "hydra-submitit-launcher>=1.2.0",
     "optuna>=2.10.1",
+    "metabo-depthcharge",
 ]
 
 [project.optional-dependencies]
@@ -227,6 +228,9 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
 ]
+
+[tool.uv.sources]
+metabo-depthcharge = { path = "../metabo-depthcharge", editable = true }
 
 [dependency-groups]
 dev = [

--- a/simba/configs/model/simba_default.yaml
+++ b/simba/configs/model/simba_default.yaml
@@ -39,6 +39,7 @@ features:
   use_ce: false
   use_ion_activation: false
   use_ion_method: false
+  pool: "attention"
 
 # Task configuration
 tasks:

--- a/simba/core/chemistry/edit_distance/edit_distance.py
+++ b/simba/core/chemistry/edit_distance/edit_distance.py
@@ -804,13 +804,13 @@ def simba_solve_pair_mces(
                 # solver_options={'threads': 1, 'msg': False},  # use single thread + no console messages
                 no_ilp_threshold=False,  # allow the ILP to stop early once the threshold is exceeded
                 always_stronger_bound=True,
-                catch_errors=False,  # typically raise exceptions if something goes wrong
+                catch_errors=True,  # return distance=-1 on solver failure instead of raising
             )
             distance = result[1]
             time_taken = result[2]
             exact_answer = result[3]
 
-            if time_taken >= (0.9 * TIME_LIMIT) and (exact_answer != 1):
+            if distance == -1 or (time_taken >= (0.9 * TIME_LIMIT) and (exact_answer != 1)):
                 distance = np.nan
 
     return distance, tanimoto

--- a/simba/core/chemistry/edit_distance/edit_distance.py
+++ b/simba/core/chemistry/edit_distance/edit_distance.py
@@ -810,7 +810,9 @@ def simba_solve_pair_mces(
             time_taken = result[2]
             exact_answer = result[3]
 
-            if distance == -1 or (time_taken >= (0.9 * TIME_LIMIT) and (exact_answer != 1)):
+            if distance == -1 or (
+                time_taken >= (0.9 * TIME_LIMIT) and (exact_answer != 1)
+            ):
                 distance = np.nan
 
     return distance, tanimoto

--- a/simba/core/data/datasets/encoder_dataset_builder.py
+++ b/simba/core/data/datasets/encoder_dataset_builder.py
@@ -2,15 +2,13 @@ import copy
 
 import numpy as np
 from metabo_depthcharge.spec.adducts import encode_adduct
-from metabo_depthcharge.spec.metadata_parsers import encode_collision_energy
-
-from simba.core.data.datasets.encoder_dataset import CustomDatasetEncoder
-from simba.core.data.encoding import (
-    ION_ACTIVATION,
-    IONIZATION_METHODS,
+from metabo_depthcharge.spec.metadata_parsers import (
+    encode_collision_energy,
     encode_ion_activation,
     encode_ionization_method,
 )
+
+from simba.core.data.datasets.encoder_dataset import CustomDatasetEncoder
 from simba.core.data.preprocessor import Preprocessor
 
 
@@ -40,8 +38,8 @@ def prepare_encoder_dataset(spectra, max_num_peaks=100):
     ionmode = np.zeros((len(spectra), 1), dtype=np.float32)
     adduct = np.zeros(len(spectra), dtype=np.int64)
     ce = np.zeros((len(spectra), 1), dtype=np.float32)
-    ia = np.zeros((len(spectra), len(ION_ACTIVATION)), dtype=np.int32)
-    im = np.zeros((len(spectra), len(IONIZATION_METHODS)), dtype=np.int32)
+    ia = np.zeros(len(spectra), dtype=np.int64)
+    im = np.zeros(len(spectra), dtype=np.int64)
 
     for i, spectrum in enumerate(spectra):
         # check for maximum length
@@ -71,16 +69,10 @@ def prepare_encoder_dataset(spectra, max_num_peaks=100):
         ce[i] = encode_collision_energy(getattr(spectrum, "ce", None))
 
         # Ion Activation
-        if hasattr(spectrum, 'ion_activation') and spectrum.ion_activation is not None and spectrum.ion_activation != "None":
-            ia[i] = encode_ion_activation(spectrum.ion_activation)
-        else:
-            ia[i] = np.zeros(len(ION_ACTIVATION), dtype=np.int32)
+        ia[i] = encode_ion_activation(getattr(spectrum, "ion_activation", None))
 
         # Ionization Method
-        if hasattr(spectrum, 'ionization_method') and spectrum.ionization_method is not None and spectrum.ionization_method != "None":
-            im[i] = encode_ionization_method(spectrum.ionization_method)
-        else:
-            im[i] = np.zeros(len(IONIZATION_METHODS), dtype=np.int32)
+        im[i] = encode_ionization_method(getattr(spectrum, "ionization_method", None))
 
     # Normalize the intensity array
     intensity = intensity / np.sqrt(np.sum(intensity**2, axis=1, keepdims=True))

--- a/simba/core/data/datasets/encoder_dataset_builder.py
+++ b/simba/core/data/datasets/encoder_dataset_builder.py
@@ -1,19 +1,16 @@
 import copy
 
 import numpy as np
+from metabo_depthcharge.spec.adducts import encode_adduct
 
 from simba.core.data.datasets.encoder_dataset import CustomDatasetEncoder
-from simba.core.data.preprocessor import Preprocessor
-from simba.core.chemistry.chem_utils import (
-    ADDUCT_TO_MASS,
-)
 from simba.core.data.encoding import (
-    IONIZATION_METHODS,
     ION_ACTIVATION,
-    encode_adduct_mass,
-    encode_ionization_method,
+    IONIZATION_METHODS,
     encode_ion_activation,
+    encode_ionization_method,
 )
+from simba.core.data.preprocessor import Preprocessor
 
 
 def prepare_encoder_dataset(spectra, max_num_peaks=100):
@@ -37,10 +34,10 @@ def prepare_encoder_dataset(spectra, max_num_peaks=100):
     intensity = np.zeros((len(spectra), max_num_peaks), dtype=np.float32)
     precursor_mass = np.zeros((len(spectra), 1), dtype=np.float32)
     precursor_charge = np.zeros((len(spectra), 1), dtype=np.int32)
-    
+
     # Metadata fields (initialized with default values)
     ionmode = np.zeros((len(spectra), 1), dtype=np.float32)
-    adduct = np.zeros((len(spectra), len(ADDUCT_TO_MASS.keys())), dtype=np.float32)
+    adduct = np.zeros(len(spectra), dtype=np.int64)
     ce = np.zeros((len(spectra), 1), dtype=np.int32)
     ia = np.zeros((len(spectra), len(ION_ACTIVATION)), dtype=np.int32)
     im = np.zeros((len(spectra), len(IONIZATION_METHODS)), dtype=np.int32)
@@ -57,32 +54,30 @@ def prepare_encoder_dataset(spectra, max_num_peaks=100):
 
         precursor_mass[i] = spectrum.precursor_mz
         precursor_charge[i] = spectrum.precursor_charge
-        
+
         # Extract metadata if available
         # Ion mode
         if hasattr(spectrum, 'ionmode') and spectrum.ionmode is not None and spectrum.ionmode != "None":
             ionmode[i] = 1.0 if spectrum.ionmode.lower() == "positive" else -1.0
         else:
             ionmode[i] = 0.0
-        
-        # Adduct
-        if hasattr(spectrum, 'params') and 'adduct' in spectrum.params:
-            adduct[i] = encode_adduct_mass(spectrum.params['adduct'])
-        elif hasattr(spectrum, 'adduct') and spectrum.adduct is not None:
-            adduct[i] = encode_adduct_mass(spectrum.adduct)
-        
+
+        # Adduct — categorical index using metabo-depthcharge vocabulary
+        adduct_str = getattr(spectrum, "adduct", None) or ""
+        adduct[i] = encode_adduct(adduct_str)
+
         # Collision Energy
         if hasattr(spectrum, 'ce') and spectrum.ce is not None and spectrum.ce != "None":
             ce[i] = spectrum.ce
         else:
             ce[i] = 0
-        
+
         # Ion Activation
         if hasattr(spectrum, 'ion_activation') and spectrum.ion_activation is not None and spectrum.ion_activation != "None":
             ia[i] = encode_ion_activation(spectrum.ion_activation)
         else:
             ia[i] = np.zeros(len(ION_ACTIVATION), dtype=np.int32)
-        
+
         # Ionization Method
         if hasattr(spectrum, 'ionization_method') and spectrum.ionization_method is not None and spectrum.ionization_method != "None":
             im[i] = encode_ionization_method(spectrum.ionization_method)

--- a/simba/core/data/datasets/encoder_dataset_builder.py
+++ b/simba/core/data/datasets/encoder_dataset_builder.py
@@ -2,6 +2,7 @@ import copy
 
 import numpy as np
 from metabo_depthcharge.spec.adducts import encode_adduct
+from metabo_depthcharge.spec.metadata_parsers import encode_collision_energy
 
 from simba.core.data.datasets.encoder_dataset import CustomDatasetEncoder
 from simba.core.data.encoding import (
@@ -38,7 +39,7 @@ def prepare_encoder_dataset(spectra, max_num_peaks=100):
     # Metadata fields (initialized with default values)
     ionmode = np.zeros((len(spectra), 1), dtype=np.float32)
     adduct = np.zeros(len(spectra), dtype=np.int64)
-    ce = np.zeros((len(spectra), 1), dtype=np.int32)
+    ce = np.zeros((len(spectra), 1), dtype=np.float32)
     ia = np.zeros((len(spectra), len(ION_ACTIVATION)), dtype=np.int32)
     im = np.zeros((len(spectra), len(IONIZATION_METHODS)), dtype=np.int32)
 
@@ -67,10 +68,7 @@ def prepare_encoder_dataset(spectra, max_num_peaks=100):
         adduct[i] = encode_adduct(adduct_str)
 
         # Collision Energy
-        if hasattr(spectrum, 'ce') and spectrum.ce is not None and spectrum.ce != "None":
-            ce[i] = spectrum.ce
-        else:
-            ce[i] = 0
+        ce[i] = encode_collision_energy(getattr(spectrum, "ce", None))
 
         # Ion Activation
         if hasattr(spectrum, 'ion_activation') and spectrum.ion_activation is not None and spectrum.ion_activation != "None":

--- a/simba/core/data/datasets/multitask_dataset.py
+++ b/simba/core/data/datasets/multitask_dataset.py
@@ -77,37 +77,27 @@ class CustomDatasetMultitasking(Dataset):
         ## Get the mz, intensity values and precursor data
 
         dictionary = {}
-        dictionary["mz_0"] = np.zeros(
-            (len_data, max_num_peaks), dtype=np.float32
-        )
+        dictionary["mz_0"] = np.zeros((len_data, max_num_peaks), dtype=np.float32)
         dictionary["intensity_0"] = np.zeros(
             (len_data, max_num_peaks), dtype=np.float32
         )
-        dictionary["mz_1"] = np.zeros(
-            (len_data, max_num_peaks), dtype=np.float32
-        )
+        dictionary["mz_1"] = np.zeros((len_data, max_num_peaks), dtype=np.float32)
         dictionary["intensity_1"] = np.zeros(
             (len_data, max_num_peaks), dtype=np.float32
         )
         dictionary["ed"] = np.zeros((len_data, 1), dtype=np.float32)
         dictionary["mces"] = np.zeros((len_data, 1), dtype=np.float32)
-        dictionary["precursor_mass_0"] = np.zeros(
-            (len_data, 1), dtype=np.float32
-        )
-        dictionary["precursor_charge_0"] = np.zeros(
-            (len_data, 1), dtype=np.int32
-        )
-        dictionary["precursor_mass_1"] = np.zeros(
-            (len_data, 1), dtype=np.float32
-        )
-        dictionary["precursor_charge_1"] = np.zeros(
-            (len_data, 1), dtype=np.int32
-        )
+        dictionary["precursor_mass_0"] = np.zeros((len_data, 1), dtype=np.float32)
+        dictionary["precursor_charge_0"] = np.zeros((len_data, 1), dtype=np.int32)
+        dictionary["precursor_mass_1"] = np.zeros((len_data, 1), dtype=np.float32)
+        dictionary["precursor_charge_1"] = np.zeros((len_data, 1), dtype=np.int32)
 
         ### add extra metadata in case it is necessary
-        if self.use_adduct:
+        if self.use_ion_mode:
             dictionary["ionmode_0"] = np.zeros((len_data, 1), dtype=np.float32)
             dictionary["ionmode_1"] = np.zeros((len_data, 1), dtype=np.float32)
+
+        if self.use_adduct:
             dictionary["adduct_0"] = np.zeros(len_data, dtype=np.int64)
             dictionary["adduct_1"] = np.zeros(len_data, dtype=np.int64)
 
@@ -133,9 +123,7 @@ class CustomDatasetMultitasking(Dataset):
 
         if self.use_fingerprints:
             print("Defining fingerprints ...")
-            dictionary["fingerprint_0"] = np.zeros(
-                (len_data, 2048), dtype=np.int32
-            )
+            dictionary["fingerprint_0"] = np.zeros((len_data, 2048), dtype=np.int32)
 
         for idx in tqdm(range(0, len_data)):
             sample_unique = {k: self.data[k][idx] for k in self.keys}
@@ -144,27 +132,19 @@ class CustomDatasetMultitasking(Dataset):
             indexes_unique_1 = sample_unique["index_unique_1"]
 
             print(f"value of indexes_unique_0 {indexes_unique_0} ")
-            indexes_original_0 = self.df_smiles.loc[
-                int(indexes_unique_0), "indexes"
-            ][0]
+            indexes_original_0 = self.df_smiles.loc[int(indexes_unique_0), "indexes"][0]
 
-            indexes_original_1 = self.df_smiles.loc[
-                int(indexes_unique_1), "indexes"
-            ][0]
+            indexes_original_1 = self.df_smiles.loc[int(indexes_unique_1), "indexes"][0]
 
-            dictionary["mz_0"][idx] = self.mz[indexes_original_0].astype(
+            dictionary["mz_0"][idx] = self.mz[indexes_original_0].astype(np.float32)
+            dictionary["intensity_0"][idx] = self.intensity[indexes_original_0].astype(
                 np.float32
             )
-            dictionary["intensity_0"][idx] = self.intensity[
-                indexes_original_0
-            ].astype(np.float32)
 
-            dictionary["mz_1"][idx] = self.mz[indexes_original_1].astype(
+            dictionary["mz_1"][idx] = self.mz[indexes_original_1].astype(np.float32)
+            dictionary["intensity_1"][idx] = self.intensity[indexes_original_1].astype(
                 np.float32
             )
-            dictionary["intensity_1"][idx] = self.intensity[
-                indexes_original_1
-            ].astype(np.float32)
             dictionary["precursor_mass_0"][idx] = self.precursor_mass[
                 indexes_original_0
             ].astype(np.float32)
@@ -180,23 +160,19 @@ class CustomDatasetMultitasking(Dataset):
             dictionary["ed"][idx] = sample_unique["ed"].astype(np.float32)
             dictionary["mces"][idx] = sample_unique["mces"].astype(np.float32)
             if self.use_ion_mode:
-                dictionary["ionmode_0"][idx] = self.ionmode[
-                    indexes_original_0
-                ].astype(np.float32)
-                dictionary["ionmode_1"][idx] = self.ionmode[
-                    indexes_original_1
-                ].astype(np.float32)
+                dictionary["ionmode_0"][idx] = self.ionmode[indexes_original_0].astype(
+                    np.float32
+                )
+                dictionary["ionmode_1"][idx] = self.ionmode[indexes_original_1].astype(
+                    np.float32
+                )
             if self.use_adduct:
                 dictionary["adduct_0"][idx] = self.adduct_mass[indexes_original_0]
                 dictionary["adduct_1"][idx] = self.adduct_mass[indexes_original_1]
 
             if self.use_ce:
-                dictionary["ce_0"][idx] = self.ce[indexes_original_0].astype(
-                    np.float32
-                )
-                dictionary["ce_1"][idx] = self.ce[indexes_original_1].astype(
-                    np.float32
-                )
+                dictionary["ce_0"][idx] = self.ce[indexes_original_0].astype(np.float32)
+                dictionary["ce_1"][idx] = self.ce[indexes_original_1].astype(np.float32)
 
             if self.use_ion_activation:
                 dictionary["ion_activation_0"][idx] = self.ion_activation[
@@ -229,12 +205,8 @@ class CustomDatasetMultitasking(Dataset):
 
         if self.training:
             # select random samples
-            idx_0_original = random.choice(
-                self.df_smiles.loc[int(idx_0[0]), "indexes"]
-            )
-            idx_1_original = random.choice(
-                self.df_smiles.loc[int(idx_1[0]), "indexes"]
-            )
+            idx_0_original = random.choice(self.df_smiles.loc[int(idx_0[0]), "indexes"])
+            idx_1_original = random.choice(self.df_smiles.loc[int(idx_1[0]), "indexes"])
         else:
             # select the first index
             idx_0_original = self.df_smiles.loc[int(idx_0[0]), "indexes"][0]
@@ -270,18 +242,18 @@ class CustomDatasetMultitasking(Dataset):
             ind = int(idx_0[0])
             if self.training:
                 if (ind % 2) == 0:
-                    spectrum_sample["fingerprint_0"] = self.fingerprint_0[
-                        ind
-                    ].astype(np.float32)
+                    spectrum_sample["fingerprint_0"] = self.fingerprint_0[ind].astype(
+                        np.float32
+                    )
                 else:
                     # return 0s
                     spectrum_sample["fingerprint_0"] = 0 * self.fingerprint_0[
                         ind
                     ].astype(np.float32)
             else:
-                spectrum_sample["fingerprint_0"] = self.fingerprint_0[
-                    ind
-                ].astype(np.float32)
+                spectrum_sample["fingerprint_0"] = self.fingerprint_0[ind].astype(
+                    np.float32
+                )
 
         if self.use_ion_mode:
             spectrum_sample["ionmode_0"] = self.ionmode[idx_0_original].astype(
@@ -292,12 +264,12 @@ class CustomDatasetMultitasking(Dataset):
             )
 
         else:
-            spectrum_sample["ionmode_0"] = 0 * self.ionmode[
-                idx_0_original
-            ].astype(np.float32)
-            spectrum_sample["ionmode_1"] = 0 * self.ionmode[
-                idx_1_original
-            ].astype(np.float32)
+            spectrum_sample["ionmode_0"] = 0 * self.ionmode[idx_0_original].astype(
+                np.float32
+            )
+            spectrum_sample["ionmode_1"] = 0 * self.ionmode[idx_1_original].astype(
+                np.float32
+            )
 
         if self.use_adduct:
             spectrum_sample["adduct_0"] = self.adduct_mass[idx_0_original]
@@ -306,19 +278,11 @@ class CustomDatasetMultitasking(Dataset):
             spectrum_sample["adduct_0"] = np.int64(0)
             spectrum_sample["adduct_1"] = np.int64(0)
         if self.use_ce:
-            spectrum_sample["ce_0"] = self.ce[idx_0_original].astype(
-                np.float32
-            )
-            spectrum_sample["ce_1"] = self.ce[idx_1_original].astype(
-                np.float32
-            )
+            spectrum_sample["ce_0"] = self.ce[idx_0_original].astype(np.float32)
+            spectrum_sample["ce_1"] = self.ce[idx_1_original].astype(np.float32)
         else:
-            spectrum_sample["ce_0"] = 0 * self.ce[idx_0_original].astype(
-                np.float32
-            )
-            spectrum_sample["ce_1"] = 0 * self.ce[idx_1_original].astype(
-                np.float32
-            )
+            spectrum_sample["ce_0"] = 0 * self.ce[idx_0_original].astype(np.float32)
+            spectrum_sample["ce_1"] = 0 * self.ce[idx_1_original].astype(np.float32)
         if self.use_ion_activation:
             spectrum_sample["ion_activation_0"] = self.ion_activation[
                 idx_0_original
@@ -334,12 +298,12 @@ class CustomDatasetMultitasking(Dataset):
                 idx_1_original
             ].astype(np.float32)
         if self.use_ion_method:
-            spectrum_sample["ion_method_0"] = self.ion_method[
-                idx_0_original
-            ].astype(np.float32)
-            spectrum_sample["ion_method_1"] = self.ion_method[
-                idx_1_original
-            ].astype(np.float32)
+            spectrum_sample["ion_method_0"] = self.ion_method[idx_0_original].astype(
+                np.float32
+            )
+            spectrum_sample["ion_method_1"] = self.ion_method[idx_1_original].astype(
+                np.float32
+            )
         else:
             spectrum_sample["ion_method_0"] = 0 * self.ion_method[
                 idx_0_original

--- a/simba/core/data/datasets/multitask_dataset.py
+++ b/simba/core/data/datasets/multitask_dataset.py
@@ -5,10 +5,6 @@ from torch.utils.data import Dataset
 from tqdm import tqdm
 
 from simba.core.data.augmentation import Augmentation
-from simba.core.data.encoding import (
-    ION_ACTIVATION,
-    IONIZATION_METHODS,
-)
 
 
 class CustomDatasetMultitasking(Dataset):
@@ -106,20 +102,12 @@ class CustomDatasetMultitasking(Dataset):
             dictionary["ce_1"] = np.zeros((len_data, 1), dtype=np.float32)
 
         if self.use_ion_activation:
-            dictionary["ion_activation_0"] = np.zeros(
-                (len_data, len(ION_ACTIVATION)), dtype=np.float32
-            )
-            dictionary["ion_activation_1"] = np.zeros(
-                (len_data, len(ION_ACTIVATION)), dtype=np.float32
-            )
+            dictionary["ion_activation_0"] = np.zeros(len_data, dtype=np.int64)
+            dictionary["ion_activation_1"] = np.zeros(len_data, dtype=np.int64)
 
         if self.use_ion_method:
-            dictionary["ion_method_0"] = np.zeros(
-                (len_data, len(IONIZATION_METHODS)), dtype=np.float32
-            )
-            dictionary["ion_method_1"] = np.zeros(
-                (len_data, len(IONIZATION_METHODS)), dtype=np.float32
-            )
+            dictionary["ion_method_0"] = np.zeros(len_data, dtype=np.int64)
+            dictionary["ion_method_1"] = np.zeros(len_data, dtype=np.int64)
 
         if self.use_fingerprints:
             print("Defining fingerprints ...")
@@ -175,20 +163,12 @@ class CustomDatasetMultitasking(Dataset):
                 dictionary["ce_1"][idx] = self.ce[indexes_original_1].astype(np.float32)
 
             if self.use_ion_activation:
-                dictionary["ion_activation_0"][idx] = self.ion_activation[
-                    indexes_original_0
-                ].astype(np.float32)
-                dictionary["ion_activation_1"][idx] = self.ion_activation[
-                    indexes_original_1
-                ].astype(np.float32)
+                dictionary["ion_activation_0"][idx] = self.ion_activation[indexes_original_0]
+                dictionary["ion_activation_1"][idx] = self.ion_activation[indexes_original_1]
 
             if self.use_ion_method:
-                dictionary["ion_method_0"][idx] = self.ion_method[
-                    indexes_original_0
-                ].astype(np.float32)
-                dictionary["ion_method_1"][idx] = self.ion_method[
-                    indexes_original_1
-                ].astype(np.float32)
+                dictionary["ion_method_0"][idx] = self.ion_method[indexes_original_0]
+                dictionary["ion_method_1"][idx] = self.ion_method[indexes_original_1]
 
             if self.use_fingerprints:
                 dictionary["fingerprint_0"][idx] = self.fingerprint_0[
@@ -284,33 +264,17 @@ class CustomDatasetMultitasking(Dataset):
             spectrum_sample["ce_0"] = 0 * self.ce[idx_0_original].astype(np.float32)
             spectrum_sample["ce_1"] = 0 * self.ce[idx_1_original].astype(np.float32)
         if self.use_ion_activation:
-            spectrum_sample["ion_activation_0"] = self.ion_activation[
-                idx_0_original
-            ].astype(np.float32)
-            spectrum_sample["ion_activation_1"] = self.ion_activation[
-                idx_1_original
-            ].astype(np.float32)
+            spectrum_sample["ion_activation_0"] = self.ion_activation[idx_0_original]
+            spectrum_sample["ion_activation_1"] = self.ion_activation[idx_1_original]
         else:
-            spectrum_sample["ion_activation_0"] = 0 * self.ion_activation[
-                idx_0_original
-            ].astype(np.float32)
-            spectrum_sample["ion_activation_1"] = 0 * self.ion_activation[
-                idx_1_original
-            ].astype(np.float32)
+            spectrum_sample["ion_activation_0"] = np.int64(0)
+            spectrum_sample["ion_activation_1"] = np.int64(0)
         if self.use_ion_method:
-            spectrum_sample["ion_method_0"] = self.ion_method[idx_0_original].astype(
-                np.float32
-            )
-            spectrum_sample["ion_method_1"] = self.ion_method[idx_1_original].astype(
-                np.float32
-            )
+            spectrum_sample["ion_method_0"] = self.ion_method[idx_0_original]
+            spectrum_sample["ion_method_1"] = self.ion_method[idx_1_original]
         else:
-            spectrum_sample["ion_method_0"] = 0 * self.ion_method[
-                idx_0_original
-            ].astype(np.float32)
-            spectrum_sample["ion_method_1"] = 0 * self.ion_method[
-                idx_1_original
-            ].astype(np.float32)
+            spectrum_sample["ion_method_0"] = np.int64(0)
+            spectrum_sample["ion_method_1"] = np.int64(0)
         if self.training and (random.random() < self.prob_aug):
             # augmentation
             spectrum_sample = Augmentation.augment(

--- a/simba/core/data/datasets/multitask_dataset.py
+++ b/simba/core/data/datasets/multitask_dataset.py
@@ -4,12 +4,11 @@ import numpy as np
 from torch.utils.data import Dataset
 from tqdm import tqdm
 
-from simba.core.chemistry.chem_utils import ADDUCT_TO_MASS
+from simba.core.data.augmentation import Augmentation
 from simba.core.data.encoding import (
     ION_ACTIVATION,
     IONIZATION_METHODS,
 )
-from simba.core.data.augmentation import Augmentation
 
 
 class CustomDatasetMultitasking(Dataset):
@@ -109,12 +108,8 @@ class CustomDatasetMultitasking(Dataset):
         if self.use_adduct:
             dictionary["ionmode_0"] = np.zeros((len_data, 1), dtype=np.float32)
             dictionary["ionmode_1"] = np.zeros((len_data, 1), dtype=np.float32)
-            dictionary["adduct_0"] = np.zeros(
-                (len_data, len(ADDUCT_TO_MASS.keys())), dtype=np.float32
-            )
-            dictionary["adduct_1"] = np.zeros(
-                (len_data, len(ADDUCT_TO_MASS.keys())), dtype=np.float32
-            )
+            dictionary["adduct_0"] = np.zeros(len_data, dtype=np.int64)
+            dictionary["adduct_1"] = np.zeros(len_data, dtype=np.int64)
 
         if self.use_ce:
             dictionary["ce_0"] = np.zeros((len_data, 1), dtype=np.float32)
@@ -192,12 +187,8 @@ class CustomDatasetMultitasking(Dataset):
                     indexes_original_1
                 ].astype(np.float32)
             if self.use_adduct:
-                dictionary["adduct_0"][idx] = self.adduct_mass[
-                    indexes_original_0
-                ].astype(np.float32)
-                dictionary["adduct_1"][idx] = self.adduct_mass[
-                    indexes_original_1
-                ].astype(np.float32)
+                dictionary["adduct_0"][idx] = self.adduct_mass[indexes_original_0]
+                dictionary["adduct_1"][idx] = self.adduct_mass[indexes_original_1]
 
             if self.use_ce:
                 dictionary["ce_0"][idx] = self.ce[indexes_original_0].astype(
@@ -309,19 +300,11 @@ class CustomDatasetMultitasking(Dataset):
             ].astype(np.float32)
 
         if self.use_adduct:
-            spectrum_sample["adduct_0"] = self.adduct_mass[
-                idx_0_original
-            ].astype(np.float32)
-            spectrum_sample["adduct_1"] = self.adduct_mass[
-                idx_1_original
-            ].astype(np.float32)
+            spectrum_sample["adduct_0"] = self.adduct_mass[idx_0_original]
+            spectrum_sample["adduct_1"] = self.adduct_mass[idx_1_original]
         else:
-            spectrum_sample["adduct_0"] = 0 * self.adduct_mass[
-                idx_0_original
-            ].astype(np.float32)
-            spectrum_sample["adduct_1"] = 0 * self.adduct_mass[
-                idx_1_original
-            ].astype(np.float32)
+            spectrum_sample["adduct_0"] = np.int64(0)
+            spectrum_sample["adduct_1"] = np.int64(0)
         if self.use_ce:
             spectrum_sample["ce_0"] = self.ce[idx_0_original].astype(
                 np.float32

--- a/simba/core/data/datasets/multitask_dataset_builder.py
+++ b/simba/core/data/datasets/multitask_dataset_builder.py
@@ -2,17 +2,15 @@ import copy
 
 import numpy as np
 from metabo_depthcharge.spec.adducts import encode_adduct
-from metabo_depthcharge.spec.metadata_parsers import encode_collision_energy
+from metabo_depthcharge.spec.metadata_parsers import (
+    encode_collision_energy,
+    encode_ion_activation,
+    encode_ionization_method,
+)
 
 from simba.core.chemistry.tanimoto import Tanimoto
 from simba.core.data.datasets.multitask_dataset import (
     CustomDatasetMultitasking,
-)
-from simba.core.data.encoding import (
-    ION_ACTIVATION,
-    IONIZATION_METHODS,
-    encode_ion_activation,
-    encode_ionization_method,
 )
 from simba.core.data.molecule_pairs import MoleculePairsOpt
 from simba.core.data.preprocessor import Preprocessor
@@ -109,20 +107,8 @@ class MultitaskDataBuilder:
         ce = np.zeros(
             (len(molecule_pairs.original_spectra), 1), dtype=np.float32
         )
-        ia = np.zeros(
-            (
-                len(molecule_pairs.original_spectra),
-                len(ION_ACTIVATION),
-            ),
-            dtype=np.int32,
-        )
-        im = np.zeros(
-            (
-                len(molecule_pairs.original_spectra),
-                len(IONIZATION_METHODS),
-            ),
-            dtype=np.int32,
-        )
+        ia = np.zeros(len(molecule_pairs.original_spectra), dtype=np.int64)
+        im = np.zeros(len(molecule_pairs.original_spectra), dtype=np.int64)
 
         logger.info("Loading mz, intensity and precursor data ...")
         for i, spec in enumerate(molecule_pairs.original_spectra):
@@ -150,21 +136,10 @@ class MultitaskDataBuilder:
                 ce[i] = encode_collision_energy(spec.ce)
 
             if use_ion_activation:
-                if (spec.ion_activation is None) or (spec.ion_activation == "None"):
-                    ia[i] = np.zeros(len(ION_ACTIVATION), dtype=np.int32)
-                else:
-                    ia[i] = encode_ion_activation(spec.ion_activation)
+                ia[i] = encode_ion_activation(spec.ion_activation)
 
             if use_ion_method:
-                if (spec.ionization_method is None) or (
-                    spec.ionization_method == "None"
-                ):
-                    im[i] = np.zeros(
-                        len(IONIZATION_METHODS),
-                        dtype=np.int32,
-                    )
-                else:
-                    im[i] = encode_ionization_method(spec.ionization_method)
+                im[i] = encode_ionization_method(spec.ionization_method)
 
         # logger.info("Normalizing intensities")
         # Normalize the intensity array

--- a/simba/core/data/datasets/multitask_dataset_builder.py
+++ b/simba/core/data/datasets/multitask_dataset_builder.py
@@ -1,8 +1,8 @@
 import copy
 
 import numpy as np
+from metabo_depthcharge.spec.adducts import encode_adduct
 
-from simba.core.chemistry.chem_utils import ADDUCT_TO_MASS
 from simba.core.chemistry.tanimoto import Tanimoto
 from simba.core.data.datasets.multitask_dataset import (
     CustomDatasetMultitasking,
@@ -10,7 +10,6 @@ from simba.core.data.datasets.multitask_dataset import (
 from simba.core.data.encoding import (
     ION_ACTIVATION,
     IONIZATION_METHODS,
-    encode_adduct_mass,
     encode_ion_activation,
     encode_ionization_method,
 )
@@ -103,11 +102,8 @@ class MultitaskDataBuilder:
             (len(molecule_pairs.original_spectra), 1), dtype=np.float32
         )
         adduct = np.zeros(
-            (
-                len(molecule_pairs.original_spectra),
-                len(ADDUCT_TO_MASS.keys()),
-            ),
-            dtype=np.float32,
+            len(molecule_pairs.original_spectra),
+            dtype=np.int64,
         )
         ce = np.zeros(
             (len(molecule_pairs.original_spectra), 1), dtype=np.int32
@@ -147,7 +143,7 @@ class MultitaskDataBuilder:
                 else:
                     ionmode[i] = 1.0 if spec.ionmode == "positive" else -1.0
             if use_adduct:
-                adduct[i] = encode_adduct_mass(spec.params["adduct"])
+                adduct[i] = encode_adduct(spec.adduct or "")
 
             if use_ce:
                 if (spec.ce is None) or (spec.ce == "None"):

--- a/simba/core/data/datasets/multitask_dataset_builder.py
+++ b/simba/core/data/datasets/multitask_dataset_builder.py
@@ -136,10 +136,10 @@ class MultitaskDataBuilder:
                 ce[i] = encode_collision_energy(spec.ce)
 
             if use_ion_activation:
-                ia[i] = encode_ion_activation(spec.ion_activation)
+                ia[i] = encode_ion_activation(getattr(spec, "ion_activation", None))
 
             if use_ion_method:
-                im[i] = encode_ionization_method(spec.ionization_method)
+                im[i] = encode_ionization_method(getattr(spec, "ionization_method", None))
 
         # logger.info("Normalizing intensities")
         # Normalize the intensity array

--- a/simba/core/data/datasets/multitask_dataset_builder.py
+++ b/simba/core/data/datasets/multitask_dataset_builder.py
@@ -2,6 +2,7 @@ import copy
 
 import numpy as np
 from metabo_depthcharge.spec.adducts import encode_adduct
+from metabo_depthcharge.spec.metadata_parsers import encode_collision_energy
 
 from simba.core.chemistry.tanimoto import Tanimoto
 from simba.core.data.datasets.multitask_dataset import (
@@ -106,7 +107,7 @@ class MultitaskDataBuilder:
             dtype=np.int64,
         )
         ce = np.zeros(
-            (len(molecule_pairs.original_spectra), 1), dtype=np.int32
+            (len(molecule_pairs.original_spectra), 1), dtype=np.float32
         )
         ia = np.zeros(
             (
@@ -146,10 +147,7 @@ class MultitaskDataBuilder:
                 adduct[i] = encode_adduct(spec.adduct or "")
 
             if use_ce:
-                if (spec.ce is None) or (spec.ce == "None"):
-                    ce[i] = 0  # TODO: array dtype -> int
-                else:
-                    ce[i] = spec.ce
+                ce[i] = encode_collision_energy(spec.ce)
 
             if use_ion_activation:
                 if (spec.ion_activation is None) or (spec.ion_activation == "None"):

--- a/simba/core/data/encoding.py
+++ b/simba/core/data/encoding.py
@@ -1,22 +1,5 @@
-import pandas as pd
-
-from simba.core.chemistry.chem_utils import ADDUCT_TO_MASS
-
-
 ION_ACTIVATION = ["HCD", "CID"]
 IONIZATION_METHODS = ["NSI", "ESI", "APCI"]
-
-
-def encode_adduct_mass(adduct: str):
-    """Encode adduct as its mass delta in the first element of a length-1 list.
-
-    Args:
-        adduct: Adduct string (e.g., '[M+H]+')
-
-    Returns:
-        list: Length-1 list containing the mass delta, or [0] if unrecognized.
-    """
-    return [ADDUCT_TO_MASS.get(adduct, 0)]
 
 
 def encode_ion_activation(ion_activation: str):
@@ -41,51 +24,3 @@ def encode_ionization_method(ionization_method: str):
         list: One-hot encoded vector
     """
     return [1 if ionization_method == im else 0 for im in IONIZATION_METHODS]
-
-
-class OneHotEncoding:
-    def __init__(self, adduct_file_path):
-        self.df_adduct = self.load_adduct_info(adduct_file_path)
-
-    # TODO: adduct to mass dict also in simba/chem_utils.py
-    def load_adduct_info(self, path_adduct_csv):
-        return pd.read_csv(path_adduct_csv, delimiter=";")
-
-    def encode_adduct(
-        self,
-        adduct_mass,
-        ion_mode,
-    ):
-        """Encode adduct by finding the closest match in the adduct CSV by mass.
-
-        Parameters
-        ----------
-        adduct_mass : float
-            Target adduct mass (mass shift).
-        ion_mode : str
-            "positive" or "negative".
-
-        Returns
-        -------
-        list_adduct_elements : list[float or int]
-            Values of all adduct_* columns for the closest adduct.
-        """
-        mask_mode = self.df_adduct["Ion mode"].str.lower() == ion_mode.lower()
-        df_mode = self.df_adduct[mask_mode]
-
-        if df_mode.empty:
-            raise ValueError(f"No adducts found for ion mode: {ion_mode}")
-
-        idx_closest = (df_mode["Mass"] - adduct_mass).abs().idxmin()
-        best_row = df_mode.loc[idx_closest]
-
-        adduct_cols = [c for c in self.df_adduct.columns if c.startswith("adduct_")]
-        return best_row[adduct_cols].tolist()
-
-    def encode_ion_activation(self, ion_activation):
-        ion_activation_upper = ion_activation.upper() if ion_activation else ""
-        return [1 if ion_activation_upper == ia else 0 for ia in ION_ACTIVATION]
-
-    def encode_ionization_method(self, ionization_method):
-        ionization_method_upper = ionization_method.upper() if ionization_method else ""
-        return [1 if ionization_method_upper == im else 0 for im in IONIZATION_METHODS]

--- a/simba/core/data/encoding.py
+++ b/simba/core/data/encoding.py
@@ -8,34 +8,15 @@ IONIZATION_METHODS = ["NSI", "ESI", "APCI"]
 
 
 def encode_adduct_mass(adduct: str):
-    """Encode adduct as its mass.
+    """Encode adduct as its mass delta in the first element of a length-1 list.
 
     Args:
         adduct: Adduct string (e.g., '[M+H]+')
 
     Returns:
-        float: Mass of the adduct, or 0 if adduct is not recognized
+        list: Length-1 list containing the mass delta, or [0] if unrecognized.
     """
-    # TODO: how encode adduct if not recognized?
-    # Currently returns 0, but might interfere with spectra without adducts
-    adducts = ADDUCT_TO_MASS.keys()
-    response = [0 for a in adducts]
-    if adduct in adducts:
-        response[0] = ADDUCT_TO_MASS[adduct]
-    return response
-
-
-def encode_adduct_one_hot(adduct: str):
-    """Encode adduct string as one-hot vector.
-
-    Args:
-        adduct: Adduct string (e.g., '[M+H]+')
-
-    Returns:
-        list: One-hot encoded vector
-    """
-    adducts = ADDUCT_TO_MASS.keys()
-    return [1 if adduct == a else 0 for a in adducts]
+    return [ADDUCT_TO_MASS.get(adduct, 0)]
 
 
 def encode_ion_activation(ion_activation: str):
@@ -70,48 +51,36 @@ class OneHotEncoding:
     def load_adduct_info(self, path_adduct_csv):
         return pd.read_csv(path_adduct_csv, delimiter=";")
 
-    ### obtain information for adduct handling based on adduct mass
     def encode_adduct(
         self,
         adduct_mass,
         ion_mode,
     ):
-        """
+        """Encode adduct by finding the closest match in the adduct CSV by mass.
+
+        Parameters
+        ----------
         adduct_mass : float
             Target adduct mass (mass shift).
         ion_mode : str
             "positive" or "negative".
-        df_adduct : pd.DataFrame
-            DataFrame with columns:
-            - 'Ion mode'
-            - 'Mass' (adduct mass shift)
-            - adduct_* columns (adduct_M, adduct_H, adduct_Na, ...)
 
         Returns
         -------
         list_adduct_elements : list[float or int]
-            Values of all adduct_* columns (including adduct_M) for the closest adduct.
-            The order is the column order in df_adduct.
+            Values of all adduct_* columns for the closest adduct.
         """
-
-        # Keep only rows with the requested ion mode
         mask_mode = self.df_adduct["Ion mode"].str.lower() == ion_mode.lower()
         df_mode = self.df_adduct[mask_mode]
 
         if df_mode.empty:
             raise ValueError(f"No adducts found for ion mode: {ion_mode}")
 
-        # Find the row whose 'Mass' is closest to the target adduct_mass
         idx_closest = (df_mode["Mass"] - adduct_mass).abs().idxmin()
         best_row = df_mode.loc[idx_closest]
 
-        # All columns that encode adduct composition (including adduct_M)
         adduct_cols = [c for c in self.df_adduct.columns if c.startswith("adduct_")]
-
-        # Extract their values as a list (you can cast to int if you prefer)
-        list_adduct_elements = best_row[adduct_cols].tolist()
-
-        return list_adduct_elements
+        return best_row[adduct_cols].tolist()
 
     def encode_ion_activation(self, ion_activation):
         ion_activation_upper = ion_activation.upper() if ion_activation else ""

--- a/simba/core/data/loaders/loaders.py
+++ b/simba/core/data/loaders/loaders.py
@@ -458,7 +458,9 @@ class LoadData:
         else:
             adduct = None
 
-        ce = params.get("ce")
+        # Try common MGF key variants: COLLISION_ENERGY (MSG/MassSpecGym),
+        # COLLISION_ENERGY_1 (Spectraverse stepped CE), CE (legacy)
+        ce = params.get("collision_energy") or params.get("collision_energy_1") or params.get("ce")
         ia = params.get("ion_activation")
         im = params.get("ionization_method")
 

--- a/simba/core/data/loaders/loaders.py
+++ b/simba/core/data/loaders/loaders.py
@@ -6,7 +6,6 @@ import numpy as np
 from pyteomics import mgf
 from tqdm import tqdm
 
-from simba.core.chemistry import chem_utils
 from simba.core.chemistry.scaffolds import MurckoScaffold
 from simba.core.data.loaders.nist_loader import NistLoader
 from simba.core.data.preprocessor import PreprocessingUtils

--- a/simba/core/data/loaders/loaders.py
+++ b/simba/core/data/loaders/loaders.py
@@ -15,6 +15,7 @@ from simba.utils.logger_setup import logger
 
 
 class LoadData:
+    @staticmethod
     def get_spectra(
         source: IO | str,
         scan_nrs: Sequence[int] = None,
@@ -62,8 +63,7 @@ class LoadData:
             else:
 
                 def spectrum_it():
-                    for scan_nr, spectrum_dict in enumerate(f_in):
-                        yield scan_nr, spectrum_dict
+                    yield from enumerate(f_in)
 
             total_results = []
             spectra_processed = 0
@@ -312,7 +312,7 @@ class LoadData:
         """
         spectrum_name = spectrum["params"].get("name", "UNKNOWN")
 
-        if "libraryquality" in spectrum["params"].keys():
+        if "libraryquality" in spectrum["params"]:
             cond_library = int(spectrum["params"]["libraryquality"]) <= 3
         else:
             cond_library = True
@@ -326,7 +326,7 @@ class LoadData:
         # try to convert to float the pep mass
         try:
             cond_pepmass = float(spectrum["params"]["pepmass"][0]) > 0
-        except:
+        except Exception:
             cond_pepmass = False
 
         cond_mz_array = len(spectrum["m/z array"]) >= cfg.data.preprocessing.min_n_peaks
@@ -395,6 +395,7 @@ class LoadData:
 
         return total_condition, dict_results
 
+    @staticmethod
     def _parse_spectrum(
         spectrum_dict: dict,
         compute_classes: bool = False,
@@ -438,7 +439,7 @@ class LoadData:
 
         library = library
         inchi = inchi
-        smiles = params["smiles"] if "smiles" in params else ""
+        smiles = params.get("smiles", "")
 
         precursor_mz = LoadData.get_precursor_mz(spectrum_dict)
         if precursor_mz is None:
@@ -457,11 +458,11 @@ class LoadData:
         else:
             adduct = None
 
-        ce = params["ce"] if "ce" in params else None
-        ia = params["ion_activation"] if "ion_activation" in params else None
-        im = params["ionization_method"] if "ionization_method" in params else None
+        ce = params.get("ce")
+        ia = params.get("ion_activation")
+        im = params.get("ionization_method")
 
-        inchi_key = params["inchikey"] if "inchikey" in params else None
+        inchi_key = params.get("inchikey")
 
         # compute hash id value
         spectrum_hash_result = spectrum_hash(
@@ -514,6 +515,7 @@ class LoadData:
 
         return spec
 
+    @staticmethod
     def get_all_spectra_mgf(
         file: IO | str,
         num_samples: int = -1,
@@ -579,10 +581,11 @@ class LoadData:
             # go to next iteration
 
         logger.info(f"Loaded {len(spectra)} spectra from MGF file (with filtering applied)")
-        unique_molecules = len(set(s.params["smiles"] for s in spectra if "smiles" in s.params))
+        unique_molecules = len({s.params["smiles"] for s in spectra if "smiles" in s.params})
         logger.info(f"Unique molecules in loaded spectra: {unique_molecules}")
         return spectra
 
+    @staticmethod
     def get_all_spectra_nist(
         file,
         num_samples=10,
@@ -639,6 +642,7 @@ class LoadData:
 
         return all_spectra, current_line_number
 
+    @staticmethod
     def get_all_spectra_casmi(
         file,
         num_samples=10,
@@ -652,7 +656,7 @@ class LoadData:
             spectra_df = pickle.load(f)
         all_spectra_parsed = []
 
-        for index, spectra_row in spectra_df.iterrows():
+        for _index, spectra_row in spectra_df.iterrows():
             # initialize
             spectrum_dict = {}
             spectrum_dict["params"] = {}
@@ -704,6 +708,7 @@ class LoadData:
 
         return all_spectra
 
+    @staticmethod
     def get_all_spectra(
         file: IO | str,
         num_samples: int = 10,

--- a/simba/core/data/loaders/loaders.py
+++ b/simba/core/data/loaders/loaders.py
@@ -155,8 +155,12 @@ class LoadData:
                         condition_fails["inchi_smiles"] += 1
 
                 # Log conditions causing most failures
-                logger.info("Validation condition failures (spectra rejected for each condition):")
-                for condition, count in sorted(condition_fails.items(), key=lambda x: x[1], reverse=True):
+                logger.info(
+                    "Validation condition failures (spectra rejected for each condition):"
+                )
+                for condition, count in sorted(
+                    condition_fails.items(), key=lambda x: x[1], reverse=True
+                ):
                     if count > 0:
                         pct = 100.0 * count / spectra_processed
                         logger.info(f"  {condition}: {count} spectra ({pct:.1f}%)")
@@ -458,9 +462,24 @@ class LoadData:
         else:
             adduct = None
 
-        # Try common MGF key variants: COLLISION_ENERGY (MSG/MassSpecGym),
-        # COLLISION_ENERGY_1 (Spectraverse stepped CE), CE (legacy)
-        ce = params.get("collision_energy") or params.get("collision_energy_1") or params.get("ce")
+        # Normalized CE: average NORMALIZED_COLLISION_ENERGY_N (SpectraVerse).
+        # Fall back to COLLISION_ENERGY (MassSpecGym), then absolute CE_1 or CE (legacy).
+        norm_vals = [
+            float(v)
+            for k, v in params.items()
+            if k.startswith("normalized_collision_energy") and v is not None
+        ]
+        if norm_vals:
+            ce = sum(norm_vals) / len(norm_vals)
+        else:
+            ce = next(
+                (
+                    params[k]
+                    for k in ("collision_energy", "collision_energy_1", "ce")
+                    if params.get(k) is not None
+                ),
+                None,
+            )
         ia = params.get("ion_activation")
         im = params.get("ionization_method")
 
@@ -582,8 +601,12 @@ class LoadData:
                 break
             # go to next iteration
 
-        logger.info(f"Loaded {len(spectra)} spectra from MGF file (with filtering applied)")
-        unique_molecules = len({s.params["smiles"] for s in spectra if "smiles" in s.params})
+        logger.info(
+            f"Loaded {len(spectra)} spectra from MGF file (with filtering applied)"
+        )
+        unique_molecules = len(
+            {s.params["smiles"] for s in spectra if "smiles" in s.params}
+        )
         logger.info(f"Unique molecules in loaded spectra: {unique_molecules}")
         return spectra
 

--- a/simba/core/data/preprocessor.py
+++ b/simba/core/data/preprocessor.py
@@ -1,12 +1,14 @@
 import copy
 import functools
 import json
+import random
 from itertools import groupby
 
 import numpy as np
 import pandas as pd
 import requests
 from rdkit import Chem
+from tqdm import tqdm
 
 from simba.core.data.spectrum import SpectrumExt
 
@@ -153,23 +155,7 @@ class PreprocessingUtils:
             return None
 
 
-import copy
-import random
-
-import numpy as np
-from tqdm import tqdm
-
-from simba.core.data.spectrum import SpectrumExt
-
-
 class Preprocessor:
-    def __init__(self, bin_width=1, min_mz=10, max_mz=1400):
-        # Define the parameters for binning
-        self.bin_width = bin_width  # Adjust as needed to control the bin size
-        self.min_mz = min_mz
-        self.max_mz = max_mz
-        self.num_bins = int((max_mz - min_mz) / bin_width) + 1
-
     def preprocess_all_spectra(
         self,
         spectrums,
@@ -177,15 +163,12 @@ class Preprocessor:
         fragment_tol_mode="ppm",
         min_intensity=0.01,
         max_num_peaks=100,
-        # max_num_peaks=40,
         scale_intensity=None,
-        # scale_intensity="root",
         training=False,
         random_seed=42,
     ):
         random.seed(random_seed)
         for i, spectrum in tqdm(enumerate(spectrums)):
-            # try:
             if training:
                 min_intensity = 0.00
             else:
@@ -199,58 +182,6 @@ class Preprocessor:
                 max_num_peaks=max_num_peaks,
                 scale_intensity=scale_intensity,
             )
-        # except:
-        #    print('Error preprocessing spectrum')
-
-        # preprocess np vectors
-        # all_spectrums= self.process_all_spectrum_vectors(spectrums)
-        return spectrums
-
-    def preprocess_all_spectra_variable_max_peaks(
-        self,
-        spectrums,
-        fragment_tol_mass=10,
-        fragment_tol_mode="ppm",
-        min_intensity=0.01,
-        max_num_peaks=100,
-        # max_num_peaks=40,
-        scale_intensity=None,
-        # scale_intensity="root",
-        training=False,
-        random_seed=42,
-    ):
-        random.seed(random_seed)
-        for i, spectrum in tqdm(enumerate(spectrums)):
-            # try:
-            if training:
-                min_intensity = 0.00
-            else:
-                min_intensity = 0.01
-
-            spectrums[i] = self.preprocess_spectrum(
-                spectrum,
-                fragment_tol_mass=fragment_tol_mass,
-                fragment_tol_mode=fragment_tol_mode,
-                min_intensity=min_intensity,
-                max_num_peaks=max_num_peaks,
-                scale_intensity=scale_intensity,
-            )
-
-            length_mz = len(spectrums[i].mz)
-            if length_mz > 20:
-                spectrums[i] = self.preprocess_spectrum(
-                    spectrum,
-                    fragment_tol_mass=fragment_tol_mass,
-                    fragment_tol_mode=fragment_tol_mode,
-                    min_intensity=min_intensity,
-                    max_num_peaks=max(20, int(length_mz / (2.5))),
-                    scale_intensity=scale_intensity,
-                )
-        # except:
-        #    print('Error preprocessing spectrum')
-
-        # preprocess np vectors
-        # all_spectrums= self.process_all_spectrum_vectors(spectrums)
         return spectrums
 
     def preprocess_spectrum(
@@ -260,9 +191,7 @@ class Preprocessor:
         fragment_tol_mode: str = "ppm",
         min_intensity: float = 0.01,
         max_num_peaks: int = 100,
-        # max_num_peaks: int =40,
         scale_intensity: str | None = None,
-        # scale_intensity="root",
     ) -> SpectrumExt:
         """
         Preprocess a single spectrum
@@ -291,64 +220,8 @@ class Preprocessor:
             The preprocessed spectrum.
         """
 
-        # Process the spectrum.
         return (
             spectrum.remove_precursor_peak(fragment_tol_mass, fragment_tol_mode)
-            # .set_mz_range(min_mz=self.min_mz, max_mz=self.max_mz)
             .filter_intensity(min_intensity=min_intensity, max_num_peaks=max_num_peaks)
             .scale_intensity(scale_intensity)
         )
-
-    def return_spectrum_vector(self, spectrum):
-        # Initialize an empty numpy array for bin intensities
-        binned_spectrum = np.zeros(self.num_bins, dtype=np.float64)
-
-        # Iterate through the data and assign intensities to bins
-        for mz, intensity in zip(spectrum.mz, spectrum.intensity, strict=False):
-            if (mz > self.min_mz) and (mz < self.max_mz):
-                bin_index = int((mz - self.min_mz) / self.bin_width)
-                if intensity > binned_spectrum[bin_index]:
-                    binned_spectrum[bin_index] = intensity
-        return binned_spectrum
-
-    def process_all_spectrum_vectors(self, spectrums):
-        """
-        save spectrum vectors and apply preprocessing
-        """
-        for spectrum in tqdm(spectrums):
-            spectrum_vector = self.return_vector_and_preprocess(spectrum)
-            spectrum.set_spectrum_vector(spectrum_vector)
-        return spectrums
-
-    def return_vector_and_preprocess(self, spectrum):
-        spectrum_vector = self.return_spectrum_vector(spectrum)
-        spectrum_vector = self.preprocess_vector(spectrum_vector)
-        return spectrum_vector
-
-    def preprocess_vector(self, spectrum_vector, min_intensity=0.01):
-        # scale values using the maximum
-        maximum = np.max(spectrum_vector)
-        if maximum != 0:
-            spectrum_vector = spectrum_vector / maximum
-        # remove small values
-        spectrum_vector[spectrum_vector < min_intensity] = 0
-        return spectrum_vector
-
-    def get_all_binned_spectrums(self, spectrums):
-        all_binned_spectrums = np.zeros(
-            (len(spectrums), self.num_bins), dtype=np.float64
-        )
-        for i, spectrum in enumerate(spectrums):
-            all_binned_spectrums[i] = spectrum.spectrum_vector
-        return all_binned_spectrums
-
-    def return_valid_spectra_n_peaks(self, spectra_original, min_peaks):
-        """
-        return valid spectra based on the minimum number of peaks
-        """
-        input_spectra = [copy.deepcopy(s) for s in spectra_original]
-        preprocessed_spectra = self.preprocess_all_spectra(input_spectra)
-        valid_indexes = [
-            i for i, s in enumerate(preprocessed_spectra) if len(s.mz) > min_peaks
-        ]
-        return [spectra_original[i] for i in valid_indexes]

--- a/simba/core/data/preprocessor.py
+++ b/simba/core/data/preprocessor.py
@@ -62,7 +62,7 @@ class PreprocessingUtils:
         spectra_by_charge = PreprocessingUtils.order_by_charge(spectra)
 
         all_spectra = []
-        for charge, spectra_group in spectra_by_charge.items():
+        for _charge, spectra_group in spectra_by_charge.items():
             # order by mz
             mzs = np.array([s.precursor_mz for s in spectra_group])
             ordered_indexes = np.argsort(mzs)
@@ -71,12 +71,14 @@ class PreprocessingUtils:
 
         return all_spectra
 
+    @staticmethod
     def _smiles_to_mol(smiles):
         try:
             return Chem.MolFromSmiles(smiles)
-        except ArgumentError:
+        except Exception:
             return None
 
+    @staticmethod
     @functools.lru_cache
     def get_class(inchi: str, smiles: str) -> tuple[str | None, str | None, str | None]:
         """
@@ -110,6 +112,7 @@ class PreprocessingUtils:
             )
         return clss if clss is not None else (None, None, None)
 
+    @staticmethod
     @functools.lru_cache
     def _get_class(mol_type: str, mol_val: str) -> tuple[str, str, str] | None:
         """

--- a/simba/core/data/spectrum.py
+++ b/simba/core/data/spectrum.py
@@ -5,9 +5,7 @@ from spectrum_utils.spectrum import MsmsSpectrum
 
 
 class SpectrumExt(MsmsSpectrum):
-    """'
-    extended spectrum class that incorporates the binned vector
-    """
+    """Extended spectrum class with MS/MS metadata fields."""
 
     def __init__(
         self,
@@ -47,12 +45,8 @@ class SpectrumExt(MsmsSpectrum):
 
         # extra variables
         self.params = params
-        self.mz_array = None
-        self.intensity_array = None
         self.retention_time = retention_time
-        self.spectrum_vector = ""
         self.smiles = smiles
-        self.max_peak = ""
         self.library = library
         self.inchi = inchi
         self.ionmode = ionmode
@@ -77,16 +71,12 @@ class SpectrumExt(MsmsSpectrum):
 
     def __getstate__(self):
         # Get the state of the base class
-        state = super(SpectrumExt, self).__getstate__()
+        state = super().__getstate__()
         # Add state for the derived class
         state.update(
             {
                 "params": self.params,
-                "intensity_array": self.intensity_array,
-                "mz_array": self.mz_array,
-                "spectrum_vector": self.spectrum_vector,
                 "smiles": self.smiles,
-                "max_peak": self.max_peak,
                 "library": self.library,
                 "inchi": self.inchi,
                 "ionmode": self.ionmode,
@@ -113,15 +103,11 @@ class SpectrumExt(MsmsSpectrum):
 
         # Restore derived class state
         self.params = state["params"]
-        self.intensity_array = state["intensity_array"]
-        self.mz_array = state["mz_array"]
-        self.spectrum_vector = state["spectrum_vector"]
         self.smiles = state["smiles"]
-        self.max_peak = state["max_peak"]
         self.library = state["library"]
         self.inchi = state["inchi"]
         self.ionmode = state["ionmode"]
-        self.adduct = state["adduct"] if "adduct" in state.keys() else None
+        self.adduct = state.get("adduct")
         try:
             self.ce = state["ce"]
         except KeyError:
@@ -139,25 +125,11 @@ class SpectrumExt(MsmsSpectrum):
         self.classe = state["classe"]
         self.subclass = state["subclass"]
         self.murcko_scaffold = state["murcko_scaffold"]
-        try:  # in other versions, the inchi key is not present
-            self.inchi_key = state["inchi_key"]
-        except:
-            self.inchi_key = ""
-
-        try:
-            self.spectrum_hash = state["spectrum_hash"]
-        except:
-            self.spectrum_hash = None
-
-        try:
-            self.mgf_index = state["mgf_index"]
-        except:
-            self.mgf_index = None
+        self.inchi_key = state.get("inchi_key", "")
+        self.spectrum_hash = state.get("spectrum_hash")
+        self.mgf_index = state.get("mgf_index")
 
         self.fold = state.get("fold", None)
-
-    def set_spectrum_vector(self, spectrum_vector):
-        self.spectrum_vector = spectrum_vector
 
     def set_murcko_scaffold(self, murcko_scaffold):
         self.murcko_scaffold = murcko_scaffold
@@ -165,8 +137,3 @@ class SpectrumExt(MsmsSpectrum):
     def set_smiles(self, smiles):
         self.smiles = smiles
 
-    def set_max_peak(self, max_peak):
-        """
-        set the maximum amplitude in the spectrum
-        """
-        self.max_peak = max_peak

--- a/simba/core/data/weighted_sampling.py
+++ b/simba/core/data/weighted_sampling.py
@@ -1,8 +1,8 @@
 import numpy as np
-from simba.utils.binning import round_to_ordinal
-import numpy as np
 import torch
 from torch.utils.data import WeightedRandomSampler
+
+from simba.utils.binning import round_to_ordinal
 
 
 class SimilarityWeightSampler:

--- a/simba/core/models/similarity_models.py
+++ b/simba/core/models/similarity_models.py
@@ -120,8 +120,8 @@ class SimilarityModel(pl.LightningModule):
         if self.use_adduct:
             kwargs_0["ionmode"] = batch["ionmode_0"].float()
             kwargs_1["ionmode"] = batch["ionmode_1"].float()
-            kwargs_0["adduct"] = batch["adduct_0"].float()
-            kwargs_1["adduct"] = batch["adduct_1"].float()
+            kwargs_0["adduct"] = batch["adduct_0"].long()
+            kwargs_1["adduct"] = batch["adduct_1"].long()
 
         if self.use_ce:
             logger.info("Using CE in the model")
@@ -474,15 +474,8 @@ class SimilarityModelMultitask(SimilarityModel):
         )
         kwargs_0["ionmode"] = batch["ionmode_0"].float()
         kwargs_1["ionmode"] = batch["ionmode_1"].float()
-        batch["adduct_0"] = torch.nan_to_num(
-            batch["adduct_0"], nan=0.0, posinf=0.0, neginf=0.0
-        )
-        batch["adduct_1"] = torch.nan_to_num(
-            batch["adduct_1"], nan=0.0, posinf=0.0, neginf=0.0
-        )
-
-        kwargs_0["adduct"] = batch["adduct_0"].float()
-        kwargs_1["adduct"] = batch["adduct_1"].float()
+        kwargs_0["adduct"] = batch["adduct_0"].long()
+        kwargs_1["adduct"] = batch["adduct_1"].long()
 
         batch["ce_0"] = torch.nan_to_num(batch["ce_0"], nan=0.0, posinf=0.0, neginf=0.0)
         batch["ce_1"] = torch.nan_to_num(batch["ce_1"], nan=0.0, posinf=0.0, neginf=0.0)
@@ -828,7 +821,7 @@ class EmbeddingExtractor(pl.LightningModule):
         if "ionmode" in batch:
             kwargs["ionmode"] = batch["ionmode"].float()
         if "adduct" in batch:
-            kwargs["adduct"] = batch["adduct"].float()
+            kwargs["adduct"] = batch["adduct"].long()
         if "ce" in batch:
             kwargs["ce"] = batch["ce"].float()
         if "ion_activation" in batch:

--- a/simba/core/models/similarity_models.py
+++ b/simba/core/models/similarity_models.py
@@ -365,6 +365,7 @@ class SimilarityModelMultitask(SimilarityModel):
         use_ion_activation=False,
         use_ion_method=False,
         use_ion_mode=False,
+        pool: str = "attention",
     ):
         """Initialize the CCSPredictor"""
         super().__init__(
@@ -380,6 +381,7 @@ class SimilarityModelMultitask(SimilarityModel):
             use_ion_activation=use_ion_activation,
             use_ion_method=use_ion_method,
             use_ion_mode=use_ion_mode,
+            pool=pool,
         )
         self.weights = weights
 

--- a/simba/core/models/similarity_models.py
+++ b/simba/core/models/similarity_models.py
@@ -48,6 +48,7 @@ class SimilarityModel(pl.LightningModule):
         use_ion_activation=False,
         use_ion_method=False,
         use_ion_mode=False,
+        pool: str = "attention",
     ):
         """Initialize the CCSPredictor"""
         super().__init__()
@@ -70,6 +71,7 @@ class SimilarityModel(pl.LightningModule):
             d_model=d_model,
             n_layers=n_layers,
             dropout=dropout,
+            pool=pool,
             use_adduct=use_adduct,
             use_ce=use_ce,
             use_ion_activation=use_ion_activation,
@@ -488,24 +490,12 @@ class SimilarityModelMultitask(SimilarityModel):
             kwargs_1["ce"] = batch["ce_1"].float()
 
         if self.use_ion_activation:
-            batch["ion_activation_0"] = torch.nan_to_num(
-                batch["ion_activation_0"], nan=0.0, posinf=0.0, neginf=0.0
-            )
-            batch["ion_activation_1"] = torch.nan_to_num(
-                batch["ion_activation_1"], nan=0.0, posinf=0.0, neginf=0.0
-            )
-            kwargs_0["ion_activation"] = batch["ion_activation_0"].float()
-            kwargs_1["ion_activation"] = batch["ion_activation_1"].float()
+            kwargs_0["ion_activation"] = batch["ion_activation_0"].long()
+            kwargs_1["ion_activation"] = batch["ion_activation_1"].long()
 
         if self.use_ion_method:
-            batch["ion_method_0"] = torch.nan_to_num(
-                batch["ion_method_0"], nan=0.0, posinf=0.0, neginf=0.0
-            )
-            batch["ion_method_1"] = torch.nan_to_num(
-                batch["ion_method_1"], nan=0.0, posinf=0.0, neginf=0.0
-            )
-            kwargs_0["ion_method"] = batch["ion_method_0"].float()
-            kwargs_1["ion_method"] = batch["ion_method_1"].float()
+            kwargs_0["ion_method"] = batch["ion_method_0"].long()
+            kwargs_1["ion_method"] = batch["ion_method_1"].long()
         # intensity and mz
         batch["intensity_0"] = torch.nan_to_num(
             batch["intensity_0"], nan=0.0, posinf=0.0, neginf=0.0
@@ -804,6 +794,7 @@ class EmbeddingExtractor(pl.LightningModule):
                 use_ion_mode=features.get("use_ion_mode", False),
                 use_ion_activation=features.get("use_ion_activation", False),
                 use_ion_method=features.get("use_ion_method", False),
+                pool=features.get("pool", "attention"),
                 strict=strict,
             )
 

--- a/simba/core/models/similarity_models.py
+++ b/simba/core/models/similarity_models.py
@@ -146,19 +146,16 @@ class SimilarityModel(pl.LightningModule):
             batch["intensity_1"], nan=0.0, posinf=0.0, neginf=0.0
         )
 
-        emb0, _ = self.spectrum_encoder(
+        emb0 = self.spectrum_encoder(
             mz_array=batch["mz_0"].float(),
             intensity_array=batch["intensity_0"].float(),
             **kwargs_0,
         )
-        emb1, _ = self.spectrum_encoder(
+        emb1 = self.spectrum_encoder(
             mz_array=batch["mz_1"].float(),
             intensity_array=batch["intensity_1"].float(),
             **kwargs_1,
         )
-
-        emb0 = emb0[:, 0, :]
-        emb1 = emb1[:, 0, :]
 
         emb0 = self.relu(emb0)
         emb1 = self.relu(emb1)
@@ -510,19 +507,17 @@ class SimilarityModelMultitask(SimilarityModel):
         batch["mz_0"] = torch.nan_to_num(batch["mz_0"], nan=0.0, posinf=0.0, neginf=0.0)
         batch["mz_1"] = torch.nan_to_num(batch["mz_1"], nan=0.0, posinf=0.0, neginf=0.0)
 
-        emb0, _ = self.spectrum_encoder(
+        emb0 = self.spectrum_encoder(
             mz_array=batch["mz_0"].float(),
             intensity_array=batch["intensity_0"].float(),
             **kwargs_0,
         )
-        emb1, _ = self.spectrum_encoder(
+        emb1 = self.spectrum_encoder(
             mz_array=batch["mz_1"].float(),
             intensity_array=batch["intensity_1"].float(),
             **kwargs_1,
         )
 
-        emb0 = emb0[:, 0, :]
-        emb1 = emb1[:, 0, :]
         emb0 = self.relu(emb0)
         emb1 = self.relu(emb1)
 
@@ -829,13 +824,12 @@ class EmbeddingExtractor(pl.LightningModule):
         if "ion_method" in batch:
             kwargs["ion_method"] = batch["ion_method"].float()
 
-        emb, _ = self.model(
+        emb = self.model(
             mz_array=batch["mz"].float(),
             intensity_array=batch["intensity"].float(),
             **kwargs,
         )
 
-        emb = emb[:, 0, :]
         emb = self.relu(emb)
 
         return emb

--- a/simba/core/models/similarity_models.py
+++ b/simba/core/models/similarity_models.py
@@ -463,40 +463,49 @@ class SimilarityModelMultitask(SimilarityModel):
             "precursor_charge": batch["precursor_charge_1"].float(),
         }
 
-        batch["ionmode_0"] = torch.nan_to_num(
-            batch["ionmode_0"], nan=0.0, posinf=0.0, neginf=0.0
-        )
-        batch["ionmode_1"] = torch.nan_to_num(
-            batch["ionmode_1"], nan=0.0, posinf=0.0, neginf=0.0
-        )
-        kwargs_0["ionmode"] = batch["ionmode_0"].float()
-        kwargs_1["ionmode"] = batch["ionmode_1"].float()
-        kwargs_0["adduct"] = batch["adduct_0"].long()
-        kwargs_1["adduct"] = batch["adduct_1"].long()
+        if self.use_ion_mode:
+            batch["ionmode_0"] = torch.nan_to_num(
+                batch["ionmode_0"], nan=0.0, posinf=0.0, neginf=0.0
+            )
+            batch["ionmode_1"] = torch.nan_to_num(
+                batch["ionmode_1"], nan=0.0, posinf=0.0, neginf=0.0
+            )
+            kwargs_0["ionmode"] = batch["ionmode_0"].float()
+            kwargs_1["ionmode"] = batch["ionmode_1"].float()
 
-        batch["ce_0"] = torch.nan_to_num(batch["ce_0"], nan=0.0, posinf=0.0, neginf=0.0)
-        batch["ce_1"] = torch.nan_to_num(batch["ce_1"], nan=0.0, posinf=0.0, neginf=0.0)
-        kwargs_0["ce"] = batch["ce_0"].float()
-        kwargs_1["ce"] = batch["ce_1"].float()
+        if self.use_adduct:
+            kwargs_0["adduct"] = batch["adduct_0"].long()
+            kwargs_1["adduct"] = batch["adduct_1"].long()
 
-        batch["ion_activation_0"] = torch.nan_to_num(
-            batch["ion_activation_0"], nan=0.0, posinf=0.0, neginf=0.0
-        )
-        batch["ion_activation_1"] = torch.nan_to_num(
-            batch["ion_activation_1"], nan=0.0, posinf=0.0, neginf=0.0
-        )
-        kwargs_0["ion_activation"] = batch["ion_activation_0"].float()
-        kwargs_1["ion_activation"] = batch["ion_activation_1"].float()
+        if self.use_ce:
+            batch["ce_0"] = torch.nan_to_num(
+                batch["ce_0"], nan=0.0, posinf=0.0, neginf=0.0
+            )
+            batch["ce_1"] = torch.nan_to_num(
+                batch["ce_1"], nan=0.0, posinf=0.0, neginf=0.0
+            )
+            kwargs_0["ce"] = batch["ce_0"].float()
+            kwargs_1["ce"] = batch["ce_1"].float()
 
-        batch["ion_method_0"] = torch.nan_to_num(
-            batch["ion_method_0"], nan=0.0, posinf=0.0, neginf=0.0
-        )
-        batch["ion_method_1"] = torch.nan_to_num(
-            batch["ion_method_1"], nan=0.0, posinf=0.0, neginf=0.0
-        )
+        if self.use_ion_activation:
+            batch["ion_activation_0"] = torch.nan_to_num(
+                batch["ion_activation_0"], nan=0.0, posinf=0.0, neginf=0.0
+            )
+            batch["ion_activation_1"] = torch.nan_to_num(
+                batch["ion_activation_1"], nan=0.0, posinf=0.0, neginf=0.0
+            )
+            kwargs_0["ion_activation"] = batch["ion_activation_0"].float()
+            kwargs_1["ion_activation"] = batch["ion_activation_1"].float()
 
-        kwargs_0["ion_method"] = batch["ion_method_0"].float()
-        kwargs_1["ion_method"] = batch["ion_method_1"].float()
+        if self.use_ion_method:
+            batch["ion_method_0"] = torch.nan_to_num(
+                batch["ion_method_0"], nan=0.0, posinf=0.0, neginf=0.0
+            )
+            batch["ion_method_1"] = torch.nan_to_num(
+                batch["ion_method_1"], nan=0.0, posinf=0.0, neginf=0.0
+            )
+            kwargs_0["ion_method"] = batch["ion_method_0"].float()
+            kwargs_1["ion_method"] = batch["ion_method_1"].float()
         # intensity and mz
         batch["intensity_0"] = torch.nan_to_num(
             batch["intensity_0"], nan=0.0, posinf=0.0, neginf=0.0
@@ -780,6 +789,7 @@ class EmbeddingExtractor(pl.LightningModule):
         if self.multitasking:
             n_classes = self.config.model.tasks.edit_distance.n_classes
             use_gumbel = self.config.model.tasks.edit_distance.use_gumbel
+            features = self.config.model.get("features", {})
             return SimilarityModelMultitask.load_from_checkpoint(
                 model_path,
                 d_model=int(D_MODEL),
@@ -789,6 +799,11 @@ class EmbeddingExtractor(pl.LightningModule):
                 use_gumbel=use_gumbel,
                 lr=lr,
                 use_cosine_distance=use_cosine_distance,
+                use_adduct=features.get("use_adduct", False),
+                use_ce=features.get("use_ce", False),
+                use_ion_mode=features.get("use_ion_mode", False),
+                use_ion_activation=features.get("use_ion_activation", False),
+                use_ion_method=features.get("use_ion_method", False),
                 strict=strict,
             )
 

--- a/simba/core/models/spectrum_encoder.py
+++ b/simba/core/models/spectrum_encoder.py
@@ -1,8 +1,8 @@
 import torch
+import torch.nn as nn
 from depthcharge.encoders import FloatEncoder
-from depthcharge.transformers import (
-    SpectrumTransformerEncoder,
-)  # PeptideTransformerEncoder,
+from depthcharge.transformers import SpectrumTransformerEncoder
+from metabo_depthcharge.spec.adducts import N_ADDUCTS
 
 
 class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
@@ -19,18 +19,21 @@ class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
         """
         Custom Spectrum Transformer Encoder with optional metadata usage.
 
-        Attributes
+        Parameters
         ----------
         use_adduct: bool
             Whether to include adduct information in the encoding (default: False).
+            Adduct is encoded as a categorical index using the metabo-depthcharge
+            vocabulary via nn.Embedding.
         use_ce: bool
             Whether to include collision energy in the encoding (default: False).
         use_ion_activation: bool
             Whether to include ion activation information in the encoding (default: False).
         use_ion_method: bool
             Whether to include ionization method in the encoding (default: False).
+        use_ion_mode: bool
+            Whether to include ion mode in the encoding (default: False).
         """
-        self.use_encoders = False
         super().__init__(*args, **kwargs)
         self.use_adduct = use_adduct
         self.use_ce = use_ce
@@ -38,27 +41,15 @@ class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
         self.use_ion_method = use_ion_method
         self.use_ion_mode = use_ion_mode
 
-        if self.use_encoders:
-            if self.use_adduct:
-                self.adduct_encoder = FloatEncoder(self.d_model)
-                self.ionmode_encoder = FloatEncoder(self.d_model)
-            if self.use_ce:
-                self.ce_encoder = FloatEncoder(
-                    self.d_model,
-                )
-
-            if self.use_ion_activation:
-                self.ion_activation_encoder = FloatEncoder(self.d_model)
-
-            if self.use_ion_method:
-                self.ion_method_encoder = FloatEncoder(self.d_model)
-            if (
-                self.use_adduct
-                or self.use_ce
-                or self.use_ion_activation
-                or self.use_ion_method
-            ):
-                self.precursor_mz_encoder = FloatEncoder(self.d_model)
+        if use_adduct:
+            # Categorical embedding; index 0 = unknown, padding_idx=0 → zero vector
+            self.adduct_embedding = nn.Embedding(N_ADDUCTS, self.d_model, padding_idx=0)
+        if use_ce:
+            self.ce_encoder = FloatEncoder(self.d_model)
+        if use_ion_activation:
+            self.ion_activation_encoder = FloatEncoder(self.d_model)
+        if use_ion_method:
+            self.ion_method_encoder = FloatEncoder(self.d_model)
 
     def global_token_hook(
         self,
@@ -70,87 +61,35 @@ class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
         dtype = mz_array.dtype
         batch_size = mz_array.shape[0]
 
-        if not (self.use_encoders):
-            placeholder = torch.zeros(
-                (batch_size, self.d_model), dtype=dtype, device=device
-            )
-            precursor_mass = (
-                kwargs["precursor_mass"].float().to(device).view(batch_size)
-            )
-            placeholder[:, 0] = precursor_mass
+        placeholder = torch.zeros(
+            (batch_size, self.d_model), dtype=dtype, device=device
+        )
 
-            precursor_charge = (
-                kwargs["precursor_charge"].float().to(device).view(batch_size)
-            )
-            # skip the use of the precursor charge field
-            if self.use_ion_mode:
-                placeholder[:, 1] = precursor_charge
+        precursor_mass = kwargs["precursor_mass"].float().to(device).view(batch_size)
+        placeholder[:, 0] = precursor_mass
 
-            current_idx = 2  # keep track of where to insert metadata
+        precursor_charge = kwargs["precursor_charge"].float().to(device).view(batch_size)
+        if self.use_ion_mode:
+            placeholder[:, 1] = precursor_charge
 
-            ionmode = kwargs["ionmode"].float().to(device).view(batch_size)
-            if self.use_ion_mode:
-                placeholder[:, current_idx] = ionmode
-            current_idx += 1
+        ionmode = kwargs["ionmode"].float().to(device).view(batch_size)
+        if self.use_ion_mode:
+            placeholder[:, 2] = ionmode
 
-            adduct = kwargs["adduct"].float().to(device).view(batch_size, -1)
-            stop_idx = current_idx + adduct.shape[1]
-            if self.use_adduct:
-                placeholder[:, current_idx:stop_idx] = adduct
-            current_idx = stop_idx
+        if self.use_adduct:
+            adduct_idx = kwargs["adduct"].long().to(device).view(batch_size)
+            placeholder = placeholder + self.adduct_embedding(adduct_idx)
 
+        if self.use_ce:
             ce = kwargs["ce"].float().to(device).view(batch_size)
-            if self.use_ce:
-                placeholder[:, current_idx] = ce
-            current_idx += 1
+            placeholder = placeholder + self.ce_encoder(ce[:, None]).squeeze(1)
 
+        if self.use_ion_activation:
             ia = kwargs["ion_activation"].float().to(device).view(batch_size, -1)
-            stop_idx = current_idx + ia.shape[1]
-            if self.use_ion_activation:
-                placeholder[:, current_idx:stop_idx] = ia
-            current_idx = stop_idx
+            placeholder = placeholder + self.ion_activation_encoder(ia).mean(dim=1)
 
+        if self.use_ion_method:
             im = kwargs["ion_method"].float().to(device).view(batch_size, -1)
-            stop_idx = current_idx + im.shape[1]
-            if self.use_ion_method:
-                placeholder[:, current_idx:stop_idx] = im
-            current_idx = stop_idx
+            placeholder = placeholder + self.ion_method_encoder(im).mean(dim=1)
 
-            # ensure there are no nans
-            placeholder = torch.nan_to_num(placeholder, nan=0.0, posinf=0.0, neginf=0.0)
-
-        else:
-            precursor_mass = (
-                kwargs["precursor_mass"].float().to(device).view(batch_size)
-            )
-            precursor_mass_rep = self.precursor_mz_encoder(
-                precursor_mass[:, None]
-            ).squeeze(1)
-            placeholder = precursor_mass_rep + 0 * precursor_mass_rep
-
-            if self.use_adduct:
-                ionmode = kwargs["ionmode"].float().to(device).view(batch_size)
-                adduct = kwargs["adduct"].float().to(device).view(batch_size, -1)
-                ionmode_rep = self.ionmode_encoder(ionmode[:, None]).squeeze(1)
-                adduct_rep = self.adduct_encoder(adduct).mean(dim=1)
-
-                placeholder = placeholder + (ionmode_rep + adduct_rep)
-
-            if self.use_ce:
-                ce = kwargs["ce"].float().to(device).view(batch_size)
-                ce_rep = self.ce_encoder(ce[:, None]).squeeze(1)
-                placeholder = placeholder + ce_rep
-
-            if self.use_ion_method:
-                im = kwargs["ion_method"].float().to(device).view(batch_size, -1)
-                im_rep = self.ion_method_encoder(im).mean(dim=1)
-                placeholder = placeholder + im_rep
-
-            if self.use_ion_activation:
-                ia = kwargs["ion_activation"].float().to(device).view(batch_size, -1)
-                ia_rep = self.ion_activation_encoder(ia).mean(dim=1)
-                placeholder = placeholder + ia_rep
-
-            placeholder = torch.nan_to_num(placeholder, nan=0.0, posinf=0.0, neginf=0.0)
-
-        return placeholder
+        return torch.nan_to_num(placeholder, nan=0.0, posinf=0.0, neginf=0.0)

--- a/simba/core/models/spectrum_encoder.py
+++ b/simba/core/models/spectrum_encoder.py
@@ -3,16 +3,13 @@ import torch.nn as nn
 from metabo_depthcharge.encoders.spectra import MetadataEncoder, SpectrumEncoder
 
 
-N_ION_ACTIVATIONS = 2  # HCD, CID
-N_ION_METHODS = 3  # NSI, ESI, APCI
-
-
 class SpectrumTransformerEncoderCustom(SpectrumEncoder):
     """Spectrum encoder based on metabo-depthcharge's SpectrumEncoder.
 
-    Extends it with simba-specific fields (ion_mode, ion_activation,
-    ion_method) injected into the global token via global_token_hook.
-    Uses attention pooling — forward() returns (B, d_model).
+    Extends it with simba-specific fields (ion_mode) injected into the global
+    token via global_token_hook. Adduct, CE, ion_activation, and
+    ionization_method are handled by MetadataEncoder. Pool mode is
+    configurable: "attention" (default) or "cls".
 
     Parameters
     ----------
@@ -22,21 +19,25 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
         Number of transformer layers.
     dropout : float
         Dropout rate.
+    pool : str
+        Pooling mode passed to SpectrumEncoder: ``"attention"`` (weighted sum
+        over all tokens via AttnAggregator) or ``"cls"`` (CLS token only).
     use_adduct : bool
         Adduct encoded via MetadataEncoder (categorical embedding).
     use_ce : bool
         Collision energy encoded via MetadataEncoder (linear, zero-masked).
     use_ion_activation : bool
-        Ion activation one-hot (HCD/CID), projected via nn.Linear.
+        Ion activation encoded via MetadataEncoder (categorical embedding).
     use_ion_method : bool
-        Ionization method one-hot (NSI/ESI/APCI), projected via nn.Linear.
+        Ionization method encoded via MetadataEncoder (categorical embedding).
     use_ion_mode : bool
-        Ion mode scalar (+1/-1/0), projected via nn.Linear.
+        Ion mode scalar (+1/-1/0), projected via nn.Linear into global token.
     """
 
     def __init__(
         self,
         *args,
+        pool: str = "attention",
         use_adduct: bool = False,
         use_ce: bool = False,
         use_ion_activation: bool = False,
@@ -51,12 +52,16 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
             metadata_fields.append("adduct")
         if use_ce:
             metadata_fields.append("collision_energy")
+        if use_ion_activation:
+            metadata_fields.append("ion_activation")
+        if use_ion_method:
+            metadata_fields.append("ionization_method")
         metadata_enc = (
             MetadataEncoder(d_model, metadata_fields) if metadata_fields else None
         )
 
         super().__init__(
-            *args, pool="attention", metadata_encoder=metadata_enc, **kwargs
+            *args, pool=pool, metadata_encoder=metadata_enc, **kwargs
         )
 
         self.use_adduct = use_adduct
@@ -68,10 +73,6 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
 
         if use_ion_mode:
             self.ion_mode_proj = nn.Linear(1, self.d_model)
-        if use_ion_activation:
-            self.ion_activation_proj = nn.Linear(N_ION_ACTIVATIONS, self.d_model)
-        if use_ion_method:
-            self.ion_method_proj = nn.Linear(N_ION_METHODS, self.d_model)
 
     def forward(
         self,
@@ -105,6 +106,14 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
             metadata["collision_energy"] = (
                 kwargs["ce"].float().to(device).view(batch_size)
             )
+        if self.use_ion_activation and "ion_activation" in kwargs:
+            metadata["ion_activation"] = (
+                kwargs["ion_activation"].long().to(device).view(batch_size)
+            )
+        if self.use_ion_method and "ion_method" in kwargs:
+            metadata["ionization_method"] = (
+                kwargs["ion_method"].long().to(device).view(batch_size)
+            )
 
         precursor_mz = kwargs["precursor_mass"].float().to(device).view(batch_size)
 
@@ -134,13 +143,5 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
         if self.use_ion_mode and "ionmode" in kwargs:
             ionmode = kwargs["ionmode"].float().to(device).view(batch_size)
             latent = latent + self.ion_mode_proj(ionmode[:, None]).squeeze(1)
-
-        if self.use_ion_activation and "ion_activation" in kwargs:
-            ia = kwargs["ion_activation"].float().to(device).view(batch_size, -1)
-            latent = latent + self.ion_activation_proj(ia)
-
-        if self.use_ion_method and "ion_method" in kwargs:
-            im = kwargs["ion_method"].float().to(device).view(batch_size, -1)
-            latent = latent + self.ion_method_proj(im)
 
         return latent

--- a/simba/core/models/spectrum_encoder.py
+++ b/simba/core/models/spectrum_encoder.py
@@ -51,9 +51,13 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
             metadata_fields.append("adduct")
         if use_ce:
             metadata_fields.append("collision_energy")
-        metadata_enc = MetadataEncoder(d_model, metadata_fields) if metadata_fields else None
+        metadata_enc = (
+            MetadataEncoder(d_model, metadata_fields) if metadata_fields else None
+        )
 
-        super().__init__(*args, pool="attention", metadata_encoder=metadata_enc, **kwargs)
+        super().__init__(
+            *args, pool="attention", metadata_encoder=metadata_enc, **kwargs
+        )
 
         self.use_adduct = use_adduct
         self.use_ce = use_ce
@@ -98,7 +102,9 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
         if self.use_adduct and "adduct" in kwargs:
             metadata["adduct"] = kwargs["adduct"].long().to(device).view(batch_size)
         if self.use_ce and "ce" in kwargs:
-            metadata["collision_energy"] = kwargs["ce"].float().to(device).view(batch_size)
+            metadata["collision_energy"] = (
+                kwargs["ce"].float().to(device).view(batch_size)
+            )
 
         precursor_mz = kwargs["precursor_mass"].float().to(device).view(batch_size)
 

--- a/simba/core/models/spectrum_encoder.py
+++ b/simba/core/models/spectrum_encoder.py
@@ -1,8 +1,7 @@
 import torch
-import torch.nn as nn
 from depthcharge.encoders import FloatEncoder
 from depthcharge.transformers import SpectrumTransformerEncoder
-from metabo_depthcharge.spec.adducts import N_ADDUCTS
+from metabo_depthcharge.encoders.spectra import MetadataEncoder
 
 
 class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
@@ -24,9 +23,10 @@ class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
         use_adduct: bool
             Whether to include adduct information in the encoding (default: False).
             Adduct is encoded as a categorical index using the metabo-depthcharge
-            vocabulary via nn.Embedding.
+            vocabulary via MetadataEncoder.
         use_ce: bool
             Whether to include collision energy in the encoding (default: False).
+            CE=0 is treated as missing and masked to zero (no bias leakage).
         use_ion_activation: bool
             Whether to include ion activation information in the encoding (default: False).
         use_ion_method: bool
@@ -41,11 +41,16 @@ class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
         self.use_ion_method = use_ion_method
         self.use_ion_mode = use_ion_mode
 
+        metadata_fields = []
         if use_adduct:
-            # Categorical embedding; index 0 = unknown, padding_idx=0 → zero vector
-            self.adduct_embedding = nn.Embedding(N_ADDUCTS, self.d_model, padding_idx=0)
+            metadata_fields.append("adduct")
         if use_ce:
-            self.ce_encoder = FloatEncoder(self.d_model)
+            metadata_fields.append("collision_energy")
+        if metadata_fields:
+            self.metadata_encoder = MetadataEncoder(self.d_model, metadata_fields)
+        else:
+            self.metadata_encoder = None
+
         if use_ion_activation:
             self.ion_activation_encoder = FloatEncoder(self.d_model)
         if use_ion_method:
@@ -76,13 +81,13 @@ class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
         if self.use_ion_mode:
             placeholder[:, 2] = ionmode
 
-        if self.use_adduct:
-            adduct_idx = kwargs["adduct"].long().to(device).view(batch_size)
-            placeholder = placeholder + self.adduct_embedding(adduct_idx)
-
-        if self.use_ce:
-            ce = kwargs["ce"].float().to(device).view(batch_size)
-            placeholder = placeholder + self.ce_encoder(ce[:, None]).squeeze(1)
+        if self.metadata_encoder is not None:
+            metadata = {}
+            if self.use_adduct:
+                metadata["adduct"] = kwargs["adduct"].long().to(device).view(batch_size)
+            if self.use_ce:
+                metadata["collision_energy"] = kwargs["ce"].float().to(device).view(batch_size)
+            placeholder = placeholder + self.metadata_encoder(metadata)
 
         if self.use_ion_activation:
             ia = kwargs["ion_activation"].float().to(device).view(batch_size, -1)

--- a/simba/core/models/spectrum_encoder.py
+++ b/simba/core/models/spectrum_encoder.py
@@ -60,7 +60,7 @@ class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
             ):
                 self.precursor_mz_encoder = FloatEncoder(self.d_model)
 
-    def precursor_hook(
+    def global_token_hook(
         self,
         mz_array: torch.Tensor,
         intensity_array: torch.Tensor,

--- a/simba/core/models/spectrum_encoder.py
+++ b/simba/core/models/spectrum_encoder.py
@@ -60,9 +60,7 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
             MetadataEncoder(d_model, metadata_fields) if metadata_fields else None
         )
 
-        super().__init__(
-            *args, pool=pool, metadata_encoder=metadata_enc, **kwargs
-        )
+        super().__init__(*args, pool=pool, metadata_encoder=metadata_enc, **kwargs)
 
         self.use_adduct = use_adduct
         self.use_ce = use_ce

--- a/simba/core/models/spectrum_encoder.py
+++ b/simba/core/models/spectrum_encoder.py
@@ -1,10 +1,39 @@
 import torch
-from depthcharge.encoders import FloatEncoder
-from depthcharge.transformers import SpectrumTransformerEncoder
-from metabo_depthcharge.encoders.spectra import MetadataEncoder
+import torch.nn as nn
+from metabo_depthcharge.encoders.spectra import MetadataEncoder, SpectrumEncoder
 
 
-class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
+N_ION_ACTIVATIONS = 2  # HCD, CID
+N_ION_METHODS = 3  # NSI, ESI, APCI
+
+
+class SpectrumTransformerEncoderCustom(SpectrumEncoder):
+    """Spectrum encoder based on metabo-depthcharge's SpectrumEncoder.
+
+    Extends it with simba-specific fields (ion_mode, ion_activation,
+    ion_method) injected into the global token via global_token_hook.
+    Uses attention pooling — forward() returns (B, d_model).
+
+    Parameters
+    ----------
+    d_model : int
+        Transformer hidden dimension.
+    n_layers : int
+        Number of transformer layers.
+    dropout : float
+        Dropout rate.
+    use_adduct : bool
+        Adduct encoded via MetadataEncoder (categorical embedding).
+    use_ce : bool
+        Collision energy encoded via MetadataEncoder (linear, zero-masked).
+    use_ion_activation : bool
+        Ion activation one-hot (HCD/CID), projected via nn.Linear.
+    use_ion_method : bool
+        Ionization method one-hot (NSI/ESI/APCI), projected via nn.Linear.
+    use_ion_mode : bool
+        Ion mode scalar (+1/-1/0), projected via nn.Linear.
+    """
+
     def __init__(
         self,
         *args,
@@ -15,86 +44,94 @@ class SpectrumTransformerEncoderCustom(SpectrumTransformerEncoder):
         use_ion_mode: bool = False,
         **kwargs,
     ):
-        """
-        Custom Spectrum Transformer Encoder with optional metadata usage.
-
-        Parameters
-        ----------
-        use_adduct: bool
-            Whether to include adduct information in the encoding (default: False).
-            Adduct is encoded as a categorical index using the metabo-depthcharge
-            vocabulary via MetadataEncoder.
-        use_ce: bool
-            Whether to include collision energy in the encoding (default: False).
-            CE=0 is treated as missing and masked to zero (no bias leakage).
-        use_ion_activation: bool
-            Whether to include ion activation information in the encoding (default: False).
-        use_ion_method: bool
-            Whether to include ionization method in the encoding (default: False).
-        use_ion_mode: bool
-            Whether to include ion mode in the encoding (default: False).
-        """
-        super().__init__(*args, **kwargs)
-        self.use_adduct = use_adduct
-        self.use_ce = use_ce
-        self.use_ion_activation = use_ion_activation
-        self.use_ion_method = use_ion_method
-        self.use_ion_mode = use_ion_mode
+        d_model = kwargs.get("d_model", args[0] if args else 512)
 
         metadata_fields = []
         if use_adduct:
             metadata_fields.append("adduct")
         if use_ce:
             metadata_fields.append("collision_energy")
-        if metadata_fields:
-            self.metadata_encoder = MetadataEncoder(self.d_model, metadata_fields)
-        else:
-            self.metadata_encoder = None
+        metadata_enc = MetadataEncoder(d_model, metadata_fields) if metadata_fields else None
 
+        super().__init__(*args, pool="attention", metadata_encoder=metadata_enc, **kwargs)
+
+        self.use_adduct = use_adduct
+        self.use_ce = use_ce
+        self.use_ion_activation = use_ion_activation
+        self.use_ion_method = use_ion_method
+        self.use_ion_mode = use_ion_mode
+        self._extra_kwargs: dict = {}
+
+        if use_ion_mode:
+            self.ion_mode_proj = nn.Linear(1, self.d_model)
         if use_ion_activation:
-            self.ion_activation_encoder = FloatEncoder(self.d_model)
+            self.ion_activation_proj = nn.Linear(N_ION_ACTIVATIONS, self.d_model)
         if use_ion_method:
-            self.ion_method_encoder = FloatEncoder(self.d_model)
+            self.ion_method_proj = nn.Linear(N_ION_METHODS, self.d_model)
+
+    def forward(
+        self,
+        mz_array: torch.Tensor,
+        intensity_array: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Encode a batch of spectra.
+
+        Accepts the simba-style keyword arguments that similarity_models passes
+        (precursor_mass, adduct, ce, ionmode, ...) and returns a (B, d_model)
+        tensor of spectrum embeddings via attention pooling.
+
+        Parameters
+        ----------
+        mz_array : torch.Tensor of shape (B, L)
+        intensity_array : torch.Tensor of shape (B, L)
+        **kwargs : dict
+            precursor_mass, precursor_charge, ionmode, adduct, ce,
+            ion_activation, ion_method as passed by SimilarityModelMultitask.
+        """
+        device = mz_array.device
+        batch_size = mz_array.shape[0]
+
+        self._extra_kwargs = kwargs
+
+        metadata = {}
+        if self.use_adduct and "adduct" in kwargs:
+            metadata["adduct"] = kwargs["adduct"].long().to(device).view(batch_size)
+        if self.use_ce and "ce" in kwargs:
+            metadata["collision_energy"] = kwargs["ce"].float().to(device).view(batch_size)
+
+        precursor_mz = kwargs["precursor_mass"].float().to(device).view(batch_size)
+
+        return super().forward(
+            mz=mz_array,
+            intensity=intensity_array,
+            precursor_mz=precursor_mz,
+            metadata=metadata if metadata else None,
+        )
 
     def global_token_hook(
         self,
         mz_array: torch.Tensor,
         intensity_array: torch.Tensor,
-        **kwargs: dict,
-    ):
+        precursor_mzs: torch.Tensor,
+    ) -> torch.Tensor:
+        """Global token = parent CLS + precursor_mz + simba-specific metadata."""
+        latent = super().global_token_hook(mz_array, intensity_array, precursor_mzs)
+
+        kwargs = self._extra_kwargs
         device = mz_array.device
-        dtype = mz_array.dtype
         batch_size = mz_array.shape[0]
 
-        placeholder = torch.zeros(
-            (batch_size, self.d_model), dtype=dtype, device=device
-        )
+        if self.use_ion_mode and "ionmode" in kwargs:
+            ionmode = kwargs["ionmode"].float().to(device).view(batch_size)
+            latent = latent + self.ion_mode_proj(ionmode[:, None]).squeeze(1)
 
-        precursor_mass = kwargs["precursor_mass"].float().to(device).view(batch_size)
-        placeholder[:, 0] = precursor_mass
-
-        precursor_charge = kwargs["precursor_charge"].float().to(device).view(batch_size)
-        if self.use_ion_mode:
-            placeholder[:, 1] = precursor_charge
-
-        ionmode = kwargs["ionmode"].float().to(device).view(batch_size)
-        if self.use_ion_mode:
-            placeholder[:, 2] = ionmode
-
-        if self.metadata_encoder is not None:
-            metadata = {}
-            if self.use_adduct:
-                metadata["adduct"] = kwargs["adduct"].long().to(device).view(batch_size)
-            if self.use_ce:
-                metadata["collision_energy"] = kwargs["ce"].float().to(device).view(batch_size)
-            placeholder = placeholder + self.metadata_encoder(metadata)
-
-        if self.use_ion_activation:
+        if self.use_ion_activation and "ion_activation" in kwargs:
             ia = kwargs["ion_activation"].float().to(device).view(batch_size, -1)
-            placeholder = placeholder + self.ion_activation_encoder(ia).mean(dim=1)
+            latent = latent + self.ion_activation_proj(ia)
 
-        if self.use_ion_method:
+        if self.use_ion_method and "ion_method" in kwargs:
             im = kwargs["ion_method"].float().to(device).view(batch_size, -1)
-            placeholder = placeholder + self.ion_method_encoder(im).mean(dim=1)
+            latent = latent + self.ion_method_proj(im)
 
-        return torch.nan_to_num(placeholder, nan=0.0, posinf=0.0, neginf=0.0)
+        return latent

--- a/simba/core/models/spectrum_encoder.py
+++ b/simba/core/models/spectrum_encoder.py
@@ -108,12 +108,15 @@ class SpectrumTransformerEncoderCustom(SpectrumEncoder):
 
         precursor_mz = kwargs["precursor_mass"].float().to(device).view(batch_size)
 
-        return super().forward(
-            mz=mz_array,
-            intensity=intensity_array,
-            precursor_mz=precursor_mz,
-            metadata=metadata if metadata else None,
-        )
+        try:
+            return super().forward(
+                mz=mz_array,
+                intensity=intensity_array,
+                precursor_mz=precursor_mz,
+                metadata=metadata if metadata else None,
+            )
+        finally:
+            self._extra_kwargs = {}
 
     def global_token_hook(
         self,

--- a/simba/core/training/train_utils.py
+++ b/simba/core/training/train_utils.py
@@ -820,18 +820,6 @@ class TrainUtils:
             return uniform_molecule_pairs
 
     @staticmethod
-    def get_data_from_indexes(spectrums, indexes):
-        return [
-            (
-                spectrums[p[0]].spectrum_vector,
-                TrainUtils.get_global_variables(spectrums[p[0]]),
-                spectrums[p[1]].spectrum_vector,
-                TrainUtils.get_global_variables(spectrums[p[1]]),
-            )
-            for p in indexes
-        ]
-
-    @staticmethod
     def get_global_variables(spectrum):
         """
         get global variables from a spectrum such as precursor mass

--- a/simba/workflows/inference.py
+++ b/simba/workflows/inference.py
@@ -240,6 +240,7 @@ def load_model_for_inference(cfg: DictConfig, checkpoint_path: str):
         "use_ion_activation": cfg.model.features.use_ion_activation,
         "use_ion_method": cfg.model.features.use_ion_method,
         "use_ion_mode": cfg.model.features.use_ion_mode,
+        "pool": cfg.model.features.get("pool", "attention"),
     }
 
     model = SimilarityModelMultitask.load_from_checkpoint(

--- a/simba/workflows/training.py
+++ b/simba/workflows/training.py
@@ -464,6 +464,7 @@ def setup_model(cfg: DictConfig, weights_mces: np.ndarray) -> SimilarityModelMul
         "use_ion_activation": cfg.model.features.use_ion_activation,
         "use_ion_method": cfg.model.features.use_ion_method,
         "use_ion_mode": cfg.model.features.use_ion_mode,
+        "pool": cfg.model.features.get("pool", "attention"),
     }
 
     # Load pretrained weights if specified

--- a/tests/unit/test_embedder_multitask.py
+++ b/tests/unit/test_embedder_multitask.py
@@ -101,7 +101,6 @@ class TestEmbedderMultitask:
     def sample_batch(self):
         batch_size = 2
         n_peaks = 10
-        n_adducts = 48  # Length of ADDUCT_TO_MASS dictionary
 
         return {
             "mz_0": torch.randn(batch_size, n_peaks),
@@ -112,8 +111,8 @@ class TestEmbedderMultitask:
             "precursor_charge_0": torch.ones(batch_size, 1),
             "precursor_mass_1": torch.randn(batch_size, 1),
             "precursor_charge_1": torch.ones(batch_size, 1),
-            "adduct_0": torch.zeros(batch_size, n_adducts),  # One-hot encoded
-            "adduct_1": torch.zeros(batch_size, n_adducts),  # One-hot encoded
+            "adduct_0": torch.zeros(batch_size, dtype=torch.int64),  # Integer index
+            "adduct_1": torch.zeros(batch_size, dtype=torch.int64),  # Integer index
             "ionmode_0": torch.ones(batch_size, 1),
             "ionmode_1": torch.ones(batch_size, 1),
             "ce_0": torch.ones(batch_size, 1) * 30.0,

--- a/tests/unit/test_spectrum_ext.py
+++ b/tests/unit/test_spectrum_ext.py
@@ -20,19 +20,6 @@ class TestSpectrumExtSetParams:
         assert spectrum.params == params
 
 
-class TestSpectrumExtSetSpectrumVector:
-    """Test set_spectrum_vector method."""
-
-    def test_set_spectrum_vector(self, create_test_spectrum):
-        """Test setting spectrum vector."""
-        spectrum = create_test_spectrum()
-
-        vector = np.array([1.0, 2.0, 3.0])
-        spectrum.set_spectrum_vector(vector)
-
-        assert np.array_equal(spectrum.spectrum_vector, vector)
-
-
 class TestSpectrumExtSetMurckoScaffold:
     """Test set_murcko_scaffold method."""
 
@@ -57,19 +44,6 @@ class TestSpectrumExtSetSmiles:
         spectrum.set_smiles(smiles)
 
         assert spectrum.smiles == smiles
-
-
-class TestSpectrumExtSetMaxPeak:
-    """Test set_max_peak method."""
-
-    def test_set_max_peak(self, create_test_spectrum):
-        """Test setting maximum peak amplitude."""
-        spectrum = create_test_spectrum()
-
-        max_peak = 1000.0
-        spectrum.set_max_peak(max_peak)
-
-        assert spectrum.max_peak == max_peak
 
 
 class TestSpectrumExtSerialization:

--- a/tools/slurm/hyperparam_search.slurm.sh
+++ b/tools/slurm/hyperparam_search.slurm.sh
@@ -20,9 +20,9 @@
 #   same folder. Optuna skips completed trials and continues.
 # ============================================================
 
-set -e
+set -euo pipefail
 
-cd /scratch/gent/vo/000/gvo00017/vsc21162/simba
+cd /scratch/gent/vo/000/gvo00017/vsc21162/simba || exit 1
 mkdir -p logs
 source .venv/bin/activate
 

--- a/tools/slurm/inference.slurm.sh
+++ b/tools/slurm/inference.slurm.sh
@@ -9,7 +9,7 @@
 #SBATCH -o /home/nkubrakov/simba/logs/simba_inference_%j.out
 #SBATCH -e /home/nkubrakov/simba/logs/simba_inference_%j.err
 
-set -uo pipefail
+set -euo pipefail
 
 echo "===== SIMBA Inference ====="
 echo "Job ID: $SLURM_JOB_ID"
@@ -19,7 +19,7 @@ echo "Date:   $(date)"
 PREPRO_DIR=/mnt/data2/nkubrakov/massspecgym/preprocessing_th20_asb
 CHECKPOINT_DIR=/mnt/data2/nkubrakov/massspecgym/checkpoints_th20_asb
 
-cd /home/nkubrakov/simba
+cd /home/nkubrakov/simba || exit 1
 source .venv/bin/activate
 
 simba inference \

--- a/tools/slurm/inference_joint_metadata.slurm.sh
+++ b/tools/slurm/inference_joint_metadata.slurm.sh
@@ -16,7 +16,7 @@
 #   mkdir -p logs
 #   sbatch tools/slurm/inference_joint_metadata.slurm.sh
 
-set -uo pipefail
+set -euo pipefail
 
 echo "===== SIMBA Inference — Joint Dataset (metadata: adduct+CE+ion_mode) ====="
 echo "Job ID: $SLURM_JOB_ID"
@@ -30,7 +30,7 @@ OUTPUT_DIR=/mnt/data2/nkubrakov/experiments_3_dataset/metadata_adduct_ce_ionmode
 mkdir -p "${OUTPUT_DIR}"
 mkdir -p /home/nkubrakov/simba-integration/logs
 
-cd /home/nkubrakov/simba-integration
+cd /home/nkubrakov/simba-integration || exit 1
 
 uv run simba inference \
   paths.preprocessing_dir="${PREPRO_DIR}" \

--- a/tools/slurm/inference_joint_metadata.slurm.sh
+++ b/tools/slurm/inference_joint_metadata.slurm.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#SBATCH -J simba_infer_joint_metadata
+#SBATCH -p one_day
+#SBATCH --nodelist=asimov2
+#SBATCH --gpus=nvidia_h200_nvl_2g.35gb:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH -o /home/nkubrakov/simba-integration/logs/inference_joint_metadata_%j.out
+#SBATCH -e /home/nkubrakov/simba-integration/logs/inference_joint_metadata_%j.err
+
+# Inference on joint dataset using model trained with adduct + CE + ion_mode metadata.
+#
+# Usage:
+#   cd /home/nkubrakov/simba-integration
+#   mkdir -p logs
+#   sbatch tools/slurm/inference_joint_metadata.slurm.sh
+
+set -uo pipefail
+
+echo "===== SIMBA Inference — Joint Dataset (metadata: adduct+CE+ion_mode) ====="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Node:   $SLURM_NODELIST"
+echo "Date:   $(date)"
+
+PREPRO_DIR=/mnt/data2/nkubrakov/joint/preprocessing_scaffold_v1
+CHECKPOINT_DIR=/mnt/data2/nkubrakov/experiments_3_dataset/training/metadata_adduct_ce_ionmode_attn
+OUTPUT_DIR=/mnt/data2/nkubrakov/experiments_3_dataset/metadata_adduct_ce_ionmode_attn
+
+mkdir -p "${OUTPUT_DIR}"
+mkdir -p /home/nkubrakov/simba-integration/logs
+
+cd /home/nkubrakov/simba-integration
+
+uv run simba inference \
+  paths.preprocessing_dir="${PREPRO_DIR}" \
+  paths.preprocessing_dir_train="${PREPRO_DIR}" \
+  paths.checkpoint_dir="${CHECKPOINT_DIR}" \
+  paths.output_dir="${OUTPUT_DIR}" \
+  inference.use_last_model=false \
+  inference.preprocessing_pickle=mapping.pkl \
+  inference.batch_size=3072 \
+  inference.uniformize_testing=true \
+  model.features.use_adduct=true \
+  model.features.use_ce=true \
+  model.features.use_ion_mode=true \
+  hardware.accelerator=gpu \
+  hardware.devices=1 \
+  hardware.num_workers=4 \
+  logging.enable_progress_bar=true
+
+echo "===== Inference complete: $(date) ====="
+echo "Output: ${OUTPUT_DIR}"

--- a/tools/slurm/inference_joint_metadata_cls.slurm.sh
+++ b/tools/slurm/inference_joint_metadata_cls.slurm.sh
@@ -20,7 +20,7 @@
 #   mkdir -p logs
 #   sbatch tools/slurm/inference_joint_metadata_cls.slurm.sh
 
-set -uo pipefail
+set -euo pipefail
 
 echo "===== SIMBA Inference — Joint Dataset (metadata CLS-pool model) ====="
 echo "Job ID: $SLURM_JOB_ID"
@@ -34,7 +34,7 @@ OUTPUT_DIR=/mnt/data2/nkubrakov/experiments_3_dataset/metadata_adduct_ce_ionmode
 mkdir -p "${OUTPUT_DIR}"
 mkdir -p /home/nkubrakov/simba-integration/logs
 
-cd /home/nkubrakov/simba-integration
+cd /home/nkubrakov/simba-integration || exit 1
 
 uv run simba inference \
   paths.preprocessing_dir="${PREPRO_DIR}" \

--- a/tools/slurm/inference_joint_metadata_cls.slurm.sh
+++ b/tools/slurm/inference_joint_metadata_cls.slurm.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#SBATCH -J simba_infer_joint_metadata_cls
+#SBATCH -p one_day
+#SBATCH --nodelist=asimov2
+#SBATCH --gpus=nvidia_h200_nvl_2g.35gb:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH -o /home/nkubrakov/simba-integration/logs/inference_joint_metadata_cls_%j.out
+#SBATCH -e /home/nkubrakov/simba-integration/logs/inference_joint_metadata_cls_%j.err
+
+# Inference on joint dataset using model trained with adduct + CE + ion_mode metadata,
+# CLS-pool encoder (metadata_adduct_ce_ionmode checkpoint).
+# NOTE: current code uses pool="attention"; the AttnAggregator weights will be randomly
+# initialized since this checkpoint was trained with pool=None. Transformer/metadata
+# encoder weights load correctly. Results are approximate.
+#
+# Usage:
+#   cd /home/nkubrakov/simba-integration
+#   mkdir -p logs
+#   sbatch tools/slurm/inference_joint_metadata_cls.slurm.sh
+
+set -uo pipefail
+
+echo "===== SIMBA Inference — Joint Dataset (metadata CLS-pool model) ====="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Node:   $SLURM_NODELIST"
+echo "Date:   $(date)"
+
+PREPRO_DIR=/mnt/data2/nkubrakov/joint/preprocessing_scaffold_v1
+CHECKPOINT_DIR=/mnt/data2/nkubrakov/experiments_3_dataset/training/metadata_adduct_ce_ionmode
+OUTPUT_DIR=/mnt/data2/nkubrakov/experiments_3_dataset/metadata_adduct_ce_ionmode
+
+mkdir -p "${OUTPUT_DIR}"
+mkdir -p /home/nkubrakov/simba-integration/logs
+
+cd /home/nkubrakov/simba-integration
+
+uv run simba inference \
+  paths.preprocessing_dir="${PREPRO_DIR}" \
+  paths.preprocessing_dir_train="${PREPRO_DIR}" \
+  paths.checkpoint_dir="${CHECKPOINT_DIR}" \
+  paths.output_dir="${OUTPUT_DIR}" \
+  inference.use_last_model=false \
+  inference.preprocessing_pickle=mapping.pkl \
+  inference.batch_size=3072 \
+  inference.uniformize_testing=false \
+  model.features.use_adduct=true \
+  model.features.use_ce=true \
+  model.features.use_ion_mode=true \
+  hardware.accelerator=gpu \
+  hardware.devices=1 \
+  hardware.num_workers=4 \
+  logging.enable_progress_bar=true
+
+echo "===== Inference complete: $(date) ====="
+echo "Output: ${OUTPUT_DIR}"

--- a/tools/slurm/preprocessing.slurm.sh
+++ b/tools/slurm/preprocessing.slurm.sh
@@ -16,7 +16,7 @@
 #   mkdir -p logs
 #   sbatch tools/slurm/script_massspecgym_preprocessing_th20_asb.slurm.sh
 
-set -e
+set -euo pipefail
 
 SIMBA_DIR=/home/nkubrakov/simba
 MGF_PATH=/mnt/data2/nkubrakov/massspecgym/data/auxiliary/MassSpecGym.mgf
@@ -27,7 +27,7 @@ PICKLE_FILE=${OUTPUT_DIR}/mapping.pkl
 mkdir -p ${SIMBA_DIR}/logs
 mkdir -p ${OUTPUT_DIR}
 
-cd ${SIMBA_DIR}
+cd ${SIMBA_DIR} || exit 1
 
 echo "=============================================="
 echo "MassSpecGym preprocessing — TH=20, asb=True, node ${SLURM_ARRAY_TASK_ID}/2"

--- a/tools/slurm/preprocessing_nist20.slurm.sh
+++ b/tools/slurm/preprocessing_nist20.slurm.sh
@@ -20,7 +20,7 @@
 #   mkdir -p logs
 #   sbatch tools/slurm/preprocessing_nist20.slurm.sh
 
-set -e
+set -euo pipefail
 
 SIMBA_DIR=/home/nkubrakov/simba
 MGF_PATH=/mnt/data/nkubrakov/nist20/nist20.mgf
@@ -30,7 +30,7 @@ PICKLE_FILE=${OUTPUT_DIR}/mapping.pkl
 mkdir -p ${SIMBA_DIR}/logs
 mkdir -p ${OUTPUT_DIR}
 
-cd ${SIMBA_DIR}
+cd ${SIMBA_DIR} || exit 1
 
 echo "=============================================="
 echo "NIST20 preprocessing — scaffold splits, single node"

--- a/tools/slurm/preprocessing_scaffold_v2.slurm.sh
+++ b/tools/slurm/preprocessing_scaffold_v2.slurm.sh
@@ -18,7 +18,7 @@
 #   mkdir -p logs
 #   sbatch tools/slurm/preprocessing_scaffold_v2.slurm.sh
 
-set -e
+set -euo pipefail
 
 SIMBA_DIR=/home/nkubrakov/simba
 MGF_PATH=/mnt/data2/nkubrakov/massspecgym/data/auxiliary/MassSpecGym.mgf
@@ -30,7 +30,7 @@ PICKLE_FILE=${OUTPUT_DIR}/mapping.pkl
 mkdir -p ${SIMBA_DIR}/logs
 mkdir -p ${OUTPUT_DIR}
 
-cd ${SIMBA_DIR}
+cd ${SIMBA_DIR} || exit 1
 
 echo "=============================================="
 echo "MassSpecGym preprocessing — scaffold splits v2, node ${SLURM_ARRAY_TASK_ID}/2"

--- a/tools/slurm/preprocessing_spectraverse.slurm.sh
+++ b/tools/slurm/preprocessing_spectraverse.slurm.sh
@@ -18,7 +18,7 @@
 #   mkdir -p logs
 #   sbatch tools/slurm/preprocessing_spectraverse.slurm.sh
 
-set -e
+set -euo pipefail
 
 SIMBA_DIR=/home/nkubrakov/simba
 MGF_PATH=/mnt/data2/nkubrakov/spectraverse/spectraverse-1.0.1.mgf
@@ -29,7 +29,7 @@ PICKLE_FILE=${OUTPUT_DIR}/mapping.pkl
 mkdir -p ${SIMBA_DIR}/logs
 mkdir -p ${OUTPUT_DIR}
 
-cd ${SIMBA_DIR}
+cd ${SIMBA_DIR} || exit 1
 
 echo "=============================================="
 echo "Spectraverse preprocessing — scaffold splits v1, node ${SLURM_ARRAY_TASK_ID}/2"

--- a/tools/slurm/train.slurm.sh
+++ b/tools/slurm/train.slurm.sh
@@ -9,7 +9,7 @@
 #SBATCH -o /home/nkubrakov/simba/logs/simba_train_scaffold_v2_%j.out
 #SBATCH -e /home/nkubrakov/simba/logs/simba_train_scaffold_v2_%j.err
 
-set -uo pipefail
+set -euo pipefail
 
 echo "===== SIMBA Training: MSG scaffold_v2 ====="
 echo "Job ID: $SLURM_JOB_ID"
@@ -22,7 +22,7 @@ CHECKPOINT_DIR=/mnt/data2/nkubrakov/massspecgym/checkpoints_scaffold_v2
 
 mkdir -p "$CHECKPOINT_DIR"
 
-cd /home/nkubrakov/simba
+cd /home/nkubrakov/simba || exit 1
 
 export PYTORCH_ALLOC_CONF=expandable_segments:True
 

--- a/tools/slurm/train_joint_metadata.slurm.sh
+++ b/tools/slurm/train_joint_metadata.slurm.sh
@@ -9,7 +9,7 @@
 #SBATCH -o /home/nkubrakov/simba-integration/logs/simba_train_joint_metadata_%j.out
 #SBATCH -e /home/nkubrakov/simba-integration/logs/simba_train_joint_metadata_%j.err
 
-set -uo pipefail
+set -euo pipefail
 
 echo "===== SIMBA Training: Joint dataset + metadata (adduct, CE, ion_mode) ====="
 echo "Job ID: $SLURM_JOB_ID"
@@ -23,7 +23,7 @@ CHECKPOINT_DIR=/mnt/data2/nkubrakov/experiments_3_dataset/training/metadata_addu
 mkdir -p "$CHECKPOINT_DIR"
 mkdir -p /home/nkubrakov/simba-integration/logs
 
-cd /home/nkubrakov/simba-integration
+cd /home/nkubrakov/simba-integration || exit 1
 
 export PYTORCH_ALLOC_CONF=expandable_segments:True
 

--- a/tools/slurm/train_joint_metadata.slurm.sh
+++ b/tools/slurm/train_joint_metadata.slurm.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#SBATCH -J simba_train_joint_metadata
+#SBATCH -p seven_days
+#SBATCH --nodelist=asimov2
+#SBATCH --gpus=nvidia_h200_nvl_4g.71gb:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=180G
+#SBATCH -o /home/nkubrakov/simba-integration/logs/simba_train_joint_metadata_%j.out
+#SBATCH -e /home/nkubrakov/simba-integration/logs/simba_train_joint_metadata_%j.err
+
+set -uo pipefail
+
+echo "===== SIMBA Training: Joint dataset + metadata (adduct, CE, ion_mode) ====="
+echo "Job ID: $SLURM_JOB_ID"
+echo "Node:   $SLURM_NODELIST"
+echo "Date:   $(date)"
+nvidia-smi
+
+PREPRO_DIR=/mnt/data2/nkubrakov/joint/preprocessing_scaffold_v1
+CHECKPOINT_DIR=/mnt/data2/nkubrakov/experiments_3_dataset/training/metadata_adduct_ce_ionmode_attn
+
+mkdir -p "$CHECKPOINT_DIR"
+mkdir -p /home/nkubrakov/simba-integration/logs
+
+cd /home/nkubrakov/simba-integration
+
+export PYTORCH_ALLOC_CONF=expandable_segments:True
+
+uv run simba train \
+  paths.preprocessing_dir="${PREPRO_DIR}" \
+  paths.preprocessing_dir_train="${PREPRO_DIR}" \
+  paths.preprocessing_pickle_file=mapping.pkl \
+  paths.checkpoint_dir="${CHECKPOINT_DIR}" \
+  training.epochs=1000 \
+  training.batch_size=3072 \
+  training.val_check_interval=1000 \
+  training.limit_train_batches=10000 \
+  training.limit_val_batches=500 \
+  training.early_stopping_patience=10 \
+  optimizer.lr=0.0001 \
+  hardware.accelerator=gpu \
+  hardware.devices=1 \
+  hardware.num_workers=14 \
+  logging.enable_progress_bar=false \
+  logging.log_every_n_steps=10 \
+  model.features.use_adduct=true \
+  model.features.use_ce=true \
+  model.features.use_ion_mode=true
+
+echo "===== Training complete: $(date) ====="


### PR DESCRIPTION
Dependencies (pyproject.toml)

Added depthcharge-ms ≥0.4.9 and metabo-depthcharge (pinned to GitHub main)
Replaced local editable path for metabo-depthcharge with git+https://github.com/bittremieuxlab/metabo-depthcharge.git
Dead code removal

spectrum.py: stripped leftover spectrum_vector, mz_array, intensity_array, max_peak fields and the messy old __getstate__/__setstate__
encoding.py: deleted encode_adduct_mass, OneHotEncoding, ADDUCT_TO_MASS, import pandas — only ion activation/method helpers remain
preprocessor.py: removed large block of unused spectrum-vector preprocessing code
train_utils.py: removed ~12 lines of dead utility code
weighted_sampling.py: minor cleanup
ILP crash fix (edit_distance.py)

catch_errors=False → True; distance == -1 (solver failure) now maps to np.nan instead of crashing the preprocessing run
Adduct encoding (encoder_dataset_builder.py, multitask_dataset_builder.py, multitask_dataset.py)

Replaced one-hot adduct encoding over 30+ adducts with categorical integer index via encode_adduct() from metabo-depthcharge (9 known adducts + 0=unknown)
Adduct arrays changed from float32 to int64; similarity_models.py uses .long() instead of .float()
CE encoding (encoder_dataset_builder.py, multitask_dataset_builder.py)

Replaced raw float passthrough with encode_collision_energy() from metabo-depthcharge, which normalises CE÷100 and handles None/NaN/stepped strings
MGF loader (loaders.py)

CE field now read with fallback chain: collision_energy → collision_energy_1 → ce, covering MSG, Spectraverse and legacy formats
Spectrum encoder — full rewrite (spectrum_encoder.py, similarity_models.py)

Old: subclassed depthcharge's SpectrumTransformerEncoder, concatenate+project peak encoding, raw scalar global token, one-hot adduct via FloatEncoder
New: subclasses metabo-depthcharge's SpectrumEncoder — additive sinusoidal peak encoding, learned CLS + sinusoidal precursor_mz global token, MetadataEncoder for adduct (embedding) and CE (linear + zero-mask), pool="attention" (AttnAggregator over all tokens)
Zero imports from depthcharge in the encoder; ion_mode/activation/method use nn.Linear and are injected via global_token_hook override
similarity_models.py: removed 3 tuple-unpack (emb, _) sites and 3 [:, 0, :] slices — encoder now returns (B, d_model) directly
SLURM scripts (new)

train_joint_metadata.slurm.sh: trains on joint dataset with use_adduct, use_ce, use_ion_mode
inference_joint_metadata.slurm.sh: inference with the attn-pool model, proper paths.output_dir and model feature flags
inference_joint_metadata_cls.slurm.sh: inference script for the older CLS-pool checkpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added joint metadata support (adduct, collision energy, ion activation/method/ion mode) for training and inference.
  * Integrated Classyfire-based molecular class annotations into preprocessing.
* **Improvements**
  * Updated metadata-aware spectrum encoding and dataset features to align with the new joint-metadata schema.
  * Added configurable attention pooling for model encoding; updated model loading and embedding extraction.
  * Improved spectrum parsing for SMILES and collision energy extraction.
* **Bug Fixes**
  * More robust similarity scoring when the MCES solver fails.
* **Chores**
  * Updated dependency constraints and strengthened SLURM scripts with stricter failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->